### PR TITLE
docs(charge): add interactive discount/interest/fine simulator

### DIFF
--- a/docs/charge/discount-simulator.mdx
+++ b/docs/charge/discount-simulator.mdx
@@ -1,0 +1,69 @@
+---
+id: discount-simulator
+title: Simulador de desconto, juros e multa
+sidebar_label: Simulador de desconto
+---
+
+import ChargeDiscountSimulator from '@site/src/components/ChargeDiscountSimulator/ChargeDiscountSimulator';
+
+Esta página simula, **dia a dia**, o valor que um cliente paga ao longo do
+ciclo de uma cobrança Pix com vencimento (`OVERDUE` / COBV), aplicando
+desconto, juros e multa segundo as regras BACEN.
+
+A simulação roda **100% no seu navegador** — nada é enviado para a API
+da Woovi e nenhuma cobrança é criada. Use a tela como uma ferramenta de
+sandbox para entender como cada modalidade de desconto se comporta antes
+de chamar [`POST /api/v1/charge`](https://developers.woovi.com/api#tag/charge/POST/api/v1/charge)
+de verdade.
+
+## Modalidades suportadas
+
+A Woovi expõe seis modalidades de desconto, alinhadas ao padrão COBV:
+
+1. **`FIXED_VALUE_UNTIL_SPECIFIED_DATE`** — desconto em centavos válido até
+   uma data específica. Você pode cadastrar múltiplas faixas (ex.: R$1,00
+   até 5 dias antes; R$0,50 até 10 dias antes).
+2. **`PERCENTAGE_UNTIL_SPECIFIED_DATE`** — mesma ideia, mas em percentual
+   (basis points).
+3. **`VALUE_PER_RUNNING_DAY_ADVANCE`** — desconto progressivo: tantos
+   centavos a cada dia corrido de antecedência ao vencimento.
+4. **`VALUE_PER_BUSINESS_DAY_ADVANCE`** — idem, mas contando apenas dias
+   úteis (pula fins de semana e feriados bancários BR).
+5. **`PERCENTAGE_PER_RUNNING_DAY_ADVANCE`** — desconto progressivo em
+   basis points por dia corrido.
+6. **`PERCENTAGE_PER_BUSINESS_DAY_ADVANCE`** — desconto progressivo em
+   basis points por dia útil.
+
+## Convenção de unidades
+
+A Woovi (e o BACEN) usam duas unidades inteiras para evitar problemas de
+ponto flutuante:
+
+- **Centavos** — `R$1,00` = `100`. Aplica-se a `chargeValue`, ao `value`
+  das modalidades 3 e 4, às entradas de `discountFixedDate` da modalidade
+  1 e a multas com `type: 'FIXED'`.
+- **Basis points** — `1,00%` = `100`. Aplica-se ao `value` das modalidades
+  5 e 6, às entradas da modalidade 2, ao campo `interests.value` e a
+  multas com `type: 'PERCENTAGE'`.
+
+A tela mostra um *preview* legível ao lado de cada campo (`R$X,XX` ou
+`X,XX%`) para que você não precise fazer a conta na cabeça.
+
+## Modo `daily` × `summary`
+
+Por padrão a simulação devolve uma linha por dia (modo `daily`). Ative o
+toggle **Modo summary** para ver apenas os marcos relevantes: dia de
+criação, dias em que o valor de desconto muda de faixa, dia do vencimento,
+primeira diária pós-vencimento e o último dia simulado.
+
+## Exportar para a API
+
+- **Copiar JSON** devolve o envelope `{ modality, modalityNumber, input,
+  rows }` — mesmo formato emitido pela flag `--out` do script
+  `simulateChargeDiscount.ts` no monorepo Woovi. Útil para anexar em
+  bug reports ou colar em testes.
+- **Copiar como cURL** monta um `POST /api/v1/charge` pronto para rodar.
+  Substitua `<APP_ID>` pelo seu AppID e `<CORRELATION_ID>` por um
+  identificador único antes de executar.
+
+<ChargeDiscountSimulator />

--- a/i18n/en/docusaurus-plugin-content-docs/current/charge/discount-simulator.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/charge/discount-simulator.mdx
@@ -1,0 +1,71 @@
+---
+id: discount-simulator
+title: Discount, interest and fine simulator
+sidebar_label: Discount simulator
+---
+
+import ChargeDiscountSimulator from '@site/src/components/ChargeDiscountSimulator/ChargeDiscountSimulator';
+
+This page simulates, **day by day**, the amount a customer pays across the
+lifetime of a Pix charge with due date (`OVERDUE` / COBV), applying
+discount, interest and fine according to BACEN rules.
+
+The simulation runs **100% in your browser** — nothing is sent to the
+Woovi API and no charge is created. Use this screen as a sandbox to
+understand how each discount modality behaves before calling
+[`POST /api/v1/charge`](https://developers.woovi.com/api#tag/charge/POST/api/v1/charge)
+for real.
+
+> The form labels below are currently in pt-BR. Localizing the component
+> strings is tracked as a follow-up.
+
+## Supported modalities
+
+Woovi exposes six discount modalities, aligned with the COBV standard:
+
+1. **`FIXED_VALUE_UNTIL_SPECIFIED_DATE`** — fixed cents off, valid until a
+   specified date. You can register multiple tiers (e.g. R$1.00 off if
+   paid 5 days early; R$0.50 off if paid 10 days early).
+2. **`PERCENTAGE_UNTIL_SPECIFIED_DATE`** — same idea, but using percentage
+   (basis points).
+3. **`VALUE_PER_RUNNING_DAY_ADVANCE`** — progressive: N cents off for
+   each running (calendar) day before the due date.
+4. **`VALUE_PER_BUSINESS_DAY_ADVANCE`** — same as above, but counting only
+   business days (skips weekends and BR banking holidays).
+5. **`PERCENTAGE_PER_RUNNING_DAY_ADVANCE`** — progressive percentage off
+   in basis points per running day.
+6. **`PERCENTAGE_PER_BUSINESS_DAY_ADVANCE`** — progressive percentage off
+   in basis points per business day.
+
+## Unit convention
+
+Woovi (and BACEN) use two integer units to avoid floating-point issues:
+
+- **Cents** — `R$1.00` = `100`. Applies to `chargeValue`, the `value` field
+  of modalities 3 and 4, the entries of `discountFixedDate` for modality
+  1, and fines with `type: 'FIXED'`.
+- **Basis points** — `1.00%` = `100`. Applies to the `value` field of
+  modalities 5 and 6, the entries of modality 2, the `interests.value`
+  field, and fines with `type: 'PERCENTAGE'`.
+
+The screen shows a readable preview next to each field (`R$X.XX` or
+`X.XX%`) so you don't have to do the math yourself.
+
+## `daily` vs `summary` mode
+
+By default the simulation returns one row per day (`daily` mode). Toggle
+**Summary mode** to keep only the relevant milestones: creation day, days
+where the discount tier changes, the due date itself, the first day after
+the due date, and the last simulated day.
+
+## Export to the API
+
+- **Copiar JSON** returns the envelope `{ modality, modalityNumber, input,
+  rows }` — the same format emitted by the `--out` flag of the
+  `simulateChargeDiscount.ts` script in the Woovi monorepo. Handy for
+  attaching to bug reports or pasting into tests.
+- **Copiar como cURL** assembles a `POST /api/v1/charge` ready to run.
+  Replace `<APP_ID>` with your AppID and `<CORRELATION_ID>` with a unique
+  identifier before executing.
+
+<ChargeDiscountSimulator />

--- a/src/components/ChargeDiscountSimulator/ChargeDiscountSimulator.tsx
+++ b/src/components/ChargeDiscountSimulator/ChargeDiscountSimulator.tsx
@@ -1,0 +1,713 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+import {
+  DEFAULT_BR_BANKING_HOLIDAYS,
+  simulateChargeDiscount,
+} from './simulate';
+import type {
+  DiscountModality,
+  DiscountSettings,
+  FineSettings,
+  InterestSettings,
+  SimulationInput,
+  SimulationRow,
+} from './simulate';
+
+import styles from './styles.module.css';
+
+type FixedDateRow = { daysActive: number; value: number };
+
+const MODALITY_OPTIONS: {
+  number: number;
+  modality: DiscountModality;
+  label: string;
+  description: string;
+}[] = [
+  {
+    number: 1,
+    modality: 'FIXED_VALUE_UNTIL_SPECIFIED_DATE',
+    label: '1 — FIXED_VALUE_UNTIL_SPECIFIED_DATE',
+    description:
+      'Desconto fixo em centavos até uma data específica (entradas com daysActive + value em centavos).',
+  },
+  {
+    number: 2,
+    modality: 'PERCENTAGE_UNTIL_SPECIFIED_DATE',
+    label: '2 — PERCENTAGE_UNTIL_SPECIFIED_DATE',
+    description:
+      'Desconto percentual até uma data específica (entradas com daysActive + value em basis points).',
+  },
+  {
+    number: 3,
+    modality: 'VALUE_PER_RUNNING_DAY_ADVANCE',
+    label: '3 — VALUE_PER_RUNNING_DAY_ADVANCE',
+    description: 'Centavos por dia corrido de antecedência ao vencimento.',
+  },
+  {
+    number: 4,
+    modality: 'VALUE_PER_BUSINESS_DAY_ADVANCE',
+    label: '4 — VALUE_PER_BUSINESS_DAY_ADVANCE',
+    description:
+      'Centavos por dia útil de antecedência (pula fins de semana e feriados BR).',
+  },
+  {
+    number: 5,
+    modality: 'PERCENTAGE_PER_RUNNING_DAY_ADVANCE',
+    label: '5 — PERCENTAGE_PER_RUNNING_DAY_ADVANCE',
+    description:
+      'Basis points por dia corrido de antecedência ao vencimento.',
+  },
+  {
+    number: 6,
+    modality: 'PERCENTAGE_PER_BUSINESS_DAY_ADVANCE',
+    label: '6 — PERCENTAGE_PER_BUSINESS_DAY_ADVANCE',
+    description:
+      'Basis points por dia útil de antecedência (pula fins de semana e feriados BR).',
+  },
+];
+
+const isFixedDateModality = (m: DiscountModality): boolean =>
+  m === 'FIXED_VALUE_UNTIL_SPECIFIED_DATE' ||
+  m === 'PERCENTAGE_UNTIL_SPECIFIED_DATE';
+
+const modalityNumber = (m: DiscountModality): number =>
+  MODALITY_OPTIONS.find((o) => o.modality === m)?.number ?? 1;
+
+const formatCents = (cents: number): string => {
+  const sign = cents < 0 ? '-' : '';
+
+  const abs = Math.abs(cents);
+
+  return `${sign}R$${(abs / 100).toFixed(2)}`;
+};
+
+const formatBasisPoints = (bp: number): string =>
+  `${(bp / 100).toFixed(2)}%`;
+
+const todayIsoUtc = (): string => {
+  const d = new Date();
+
+  return new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  )
+    .toISOString()
+    .slice(0, 10);
+};
+
+type DiscountValueUnit = {
+  label: string;
+  preview: typeof formatCents;
+};
+
+// Discount value-unit copy per modality.
+const discountValueUnit = (m: DiscountModality): DiscountValueUnit => {
+  switch (m) {
+    case 'VALUE_PER_RUNNING_DAY_ADVANCE':
+      return { label: 'Valor (centavos por dia corrido)', preview: formatCents };
+    case 'VALUE_PER_BUSINESS_DAY_ADVANCE':
+      return { label: 'Valor (centavos por dia útil)', preview: formatCents };
+    case 'PERCENTAGE_PER_RUNNING_DAY_ADVANCE':
+      return {
+        label: 'Valor (basis points por dia corrido — 100 = 1,00%)',
+        preview: formatBasisPoints,
+      };
+    case 'PERCENTAGE_PER_BUSINESS_DAY_ADVANCE':
+      return {
+        label: 'Valor (basis points por dia útil — 100 = 1,00%)',
+        preview: formatBasisPoints,
+      };
+    default:
+      return { label: 'Valor', preview: formatCents };
+  }
+};
+
+const ChargeDiscountSimulator = (): JSX.Element => {
+  // Mount detection — avoids SSR/CSR hydration mismatch from `new Date()` used
+  // as the default creationDate. Server renders the loading fallback; client
+  // swaps in the real form post-hydration.
+  const [mounted, setMounted] = useState<boolean>(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const [modality, setModality] = useState<DiscountModality>(
+    'PERCENTAGE_PER_RUNNING_DAY_ADVANCE',
+  );
+
+  const [chargeValue, setChargeValue] = useState<number>(10000);
+
+  const [daysForDueDate, setDaysForDueDate] = useState<number>(10);
+
+  const [daysAfterDueDate, setDaysAfterDueDate] = useState<number>(15);
+
+  const [creationDate, setCreationDate] = useState<string>('');
+
+  useEffect(() => {
+    if (!creationDate) {
+      setCreationDate(todayIsoUtc());
+    }
+     
+  }, []);
+
+  const [fixedDateRows, setFixedDateRows] = useState<FixedDateRow[]>([
+    { daysActive: 5, value: 500 },
+    { daysActive: 10, value: 200 },
+  ]);
+
+  const [discountValue, setDiscountValue] = useState<number>(10);
+
+  const [noDiscount, setNoDiscount] = useState<boolean>(false);
+
+  const [interestValue, setInterestValue] = useState<number>(100);
+
+  const [noInterest, setNoInterest] = useState<boolean>(false);
+
+  const [fineValue, setFineValue] = useState<number>(200);
+
+  const [fineType, setFineType] = useState<'PERCENTAGE' | 'FIXED'>(
+    'PERCENTAGE',
+  );
+
+  const [noFine, setNoFine] = useState<boolean>(false);
+
+  const [granularity, setGranularity] = useState<'daily' | 'summary'>(
+    'daily',
+  );
+
+  const [copyStatus, setCopyStatus] = useState<string>('');
+
+  // ---------- Derived input ----------
+
+  const validation = useMemo<string | null>(() => {
+    if (!Number.isFinite(chargeValue) || chargeValue <= 0) {
+      return 'O valor da cobrança (chargeValue) deve ser maior que zero.';
+    }
+    if (!Number.isFinite(daysForDueDate) || daysForDueDate <= 0) {
+      return 'daysForDueDate deve ser maior que zero.';
+    }
+    if (!Number.isFinite(daysAfterDueDate) || daysAfterDueDate < 0) {
+      return 'daysAfterDueDate não pode ser negativo.';
+    }
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(creationDate)) {
+      return 'Data de criação inválida.';
+    }
+    return null;
+  }, [chargeValue, daysForDueDate, daysAfterDueDate, creationDate]);
+
+  const discountSettings: DiscountSettings | undefined = useMemo(() => {
+    if (noDiscount) {
+      return undefined;
+    }
+    if (isFixedDateModality(modality)) {
+      return {
+        modality: modality as
+          | 'FIXED_VALUE_UNTIL_SPECIFIED_DATE'
+          | 'PERCENTAGE_UNTIL_SPECIFIED_DATE',
+        discountFixedDate: fixedDateRows.map((r) => ({
+          daysActive: r.daysActive,
+          value: r.value,
+        })),
+      };
+    }
+    return {
+      modality: modality as
+        | 'VALUE_PER_RUNNING_DAY_ADVANCE'
+        | 'VALUE_PER_BUSINESS_DAY_ADVANCE'
+        | 'PERCENTAGE_PER_RUNNING_DAY_ADVANCE'
+        | 'PERCENTAGE_PER_BUSINESS_DAY_ADVANCE',
+      value: discountValue,
+    };
+  }, [noDiscount, modality, fixedDateRows, discountValue]);
+
+  const interests: InterestSettings | undefined = noInterest
+    ? undefined
+    : { value: interestValue };
+
+  const fines: FineSettings | undefined = noFine
+    ? undefined
+    : { value: fineValue, type: fineType };
+
+  const input = useMemo<SimulationInput>(() => {
+    return {
+      chargeValue,
+      daysForDueDate,
+      daysAfterDueDate,
+      creationDate: new Date(`${creationDate}T00:00:00Z`),
+      discountSettings,
+      interests,
+      fines,
+      granularity,
+      holidays: DEFAULT_BR_BANKING_HOLIDAYS,
+    };
+  }, [
+    chargeValue,
+    daysForDueDate,
+    daysAfterDueDate,
+    creationDate,
+    discountSettings,
+    interests,
+    fines,
+    granularity,
+  ]);
+
+  const rows: SimulationRow[] = useMemo(() => {
+    if (validation) {
+      return [];
+    }
+    try {
+      return simulateChargeDiscount(input);
+    } catch {
+      return [];
+    }
+  }, [input, validation]);
+
+  // ---------- Copy helpers ----------
+
+  const buildJsonEnvelope = (): string => {
+    const envelope = {
+      modality,
+      modalityNumber: modalityNumber(modality),
+      input: {
+        ...input,
+        creationDate: input.creationDate
+          ? new Date(input.creationDate).toISOString()
+          : undefined,
+      },
+      rows,
+    };
+
+    return JSON.stringify(envelope, null, 2);
+  };
+
+  const buildCurl = (): string => {
+    const body: Record<string, unknown> = {
+      type: 'OVERDUE',
+      correlationID: '<CORRELATION_ID>',
+      value: chargeValue,
+      daysForDueDate,
+      daysAfterDueDate,
+    };
+
+    if (discountSettings) {
+      body.discountSettings = discountSettings;
+    }
+    if (interests) {
+      body.interests = interests;
+    }
+    if (fines) {
+      body.fines = fines;
+    }
+
+    const json = JSON.stringify(body, null, 2);
+
+    return [
+      "curl -X POST 'https://api.woovi.com/api/v1/charge' \\",
+      "  -H 'Content-Type: application/json' \\",
+      "  -H 'Authorization: <APP_ID>' \\",
+      `  -d '${json}'`,
+    ].join('\n');
+  };
+
+  const copy = async (text: string, label: string): Promise<void> => {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        await navigator.clipboard.writeText(text);
+        setCopyStatus(`${label} copiado.`);
+      } else {
+        setCopyStatus('Clipboard indisponível neste navegador.');
+      }
+    } catch {
+      setCopyStatus('Falha ao copiar — selecione e copie manualmente.');
+    }
+
+    window.setTimeout(() => setCopyStatus(''), 2500);
+  };
+
+  // ---------- Sub-renderers ----------
+
+  const selectedOption = MODALITY_OPTIONS.find((o) => o.modality === modality);
+
+  const renderDiscountBlock = (): JSX.Element => {
+    if (noDiscount) {
+      return <p className={styles.muted}>Cobrança sem desconto.</p>;
+    }
+
+    if (isFixedDateModality(modality)) {
+      const isPercentage = modality === 'PERCENTAGE_UNTIL_SPECIFIED_DATE';
+
+      return (
+        <div className={styles.fixedDateGrid}>
+          <div className={styles.fixedDateHeader}>
+            <span>daysActive</span>
+            <span>
+              value{' '}
+              {isPercentage
+                ? '(basis points — 100 = 1,00%)'
+                : '(centavos)'}
+            </span>
+            <span>preview</span>
+            <span aria-hidden='true' />
+          </div>
+
+          {fixedDateRows.map((row, idx) => (
+            <div key={idx} className={styles.fixedDateRow}>
+              <input
+                type='number'
+                min={0}
+                value={row.daysActive}
+                onChange={(e) => {
+                  const next = [...fixedDateRows];
+
+                  next[idx] = {
+                    ...next[idx],
+                    daysActive: Number(e.target.value),
+                  };
+                  setFixedDateRows(next);
+                }}
+                aria-label={`daysActive linha ${idx + 1}`}
+              />
+              <input
+                type='number'
+                min={0}
+                value={row.value}
+                onChange={(e) => {
+                  const next = [...fixedDateRows];
+
+                  next[idx] = {
+                    ...next[idx],
+                    value: Number(e.target.value),
+                  };
+                  setFixedDateRows(next);
+                }}
+                aria-label={`value linha ${idx + 1}`}
+              />
+              <span className={styles.muted}>
+                {isPercentage
+                  ? formatBasisPoints(row.value)
+                  : formatCents(row.value)}
+              </span>
+              <button
+                type='button'
+                className={styles.iconButton}
+                onClick={() => {
+                  if (fixedDateRows.length === 1) {
+                    return;
+                  }
+                  const next = fixedDateRows.filter((_, i) => i !== idx);
+
+                  setFixedDateRows(next);
+                }}
+                disabled={fixedDateRows.length === 1}
+                aria-label={`Remover linha ${idx + 1}`}
+              >
+                −
+              </button>
+            </div>
+          ))}
+
+          <button
+            type='button'
+            className={styles.secondaryButton}
+            onClick={() =>
+              setFixedDateRows([
+                ...fixedDateRows,
+                { daysActive: 0, value: 0 },
+              ])
+            }
+          >
+            + Adicionar linha
+          </button>
+        </div>
+      );
+    }
+
+    const unit = discountValueUnit(modality);
+
+    return (
+      <div className={styles.field}>
+        <label htmlFor='discount-single-value'>{unit.label}</label>
+        <input
+          id='discount-single-value'
+          type='number'
+          min={0}
+          value={discountValue}
+          onChange={(e) => setDiscountValue(Number(e.target.value))}
+        />
+        <span className={styles.muted}>{unit.preview(discountValue)}</span>
+      </div>
+    );
+  };
+
+  if (!mounted) {
+    return <div className={styles.simulator}>Carregando simulador…</div>;
+  }
+
+  return (
+    <div className={styles.simulator}>
+      <div className={styles.formGrid}>
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>Modalidade</h3>
+          <div className={styles.field}>
+            <label htmlFor='modality'>Modalidade BACEN</label>
+            <select
+              id='modality'
+              value={modality}
+              onChange={(e) =>
+                setModality(e.target.value as DiscountModality)
+              }
+            >
+              {MODALITY_OPTIONS.map((o) => (
+                <option key={o.modality} value={o.modality}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+            {selectedOption && (
+              <p className={styles.muted}>{selectedOption.description}</p>
+            )}
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>Parâmetros da cobrança</h3>
+
+          <div className={styles.field}>
+            <label htmlFor='chargeValue'>Valor (centavos)</label>
+            <input
+              id='chargeValue'
+              type='number'
+              min={1}
+              value={chargeValue}
+              onChange={(e) => setChargeValue(Number(e.target.value))}
+            />
+            <span className={styles.muted}>{formatCents(chargeValue)}</span>
+          </div>
+
+          <div className={styles.field}>
+            <label htmlFor='daysForDueDate'>Dias até o vencimento</label>
+            <input
+              id='daysForDueDate'
+              type='number'
+              min={1}
+              value={daysForDueDate}
+              onChange={(e) => setDaysForDueDate(Number(e.target.value))}
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label htmlFor='daysAfterDueDate'>
+              Dias simulados após o vencimento
+            </label>
+            <input
+              id='daysAfterDueDate'
+              type='number'
+              min={0}
+              value={daysAfterDueDate}
+              onChange={(e) => setDaysAfterDueDate(Number(e.target.value))}
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label htmlFor='creationDate'>Data de criação (UTC)</label>
+            <input
+              id='creationDate'
+              type='date'
+              value={creationDate}
+              onChange={(e) => setCreationDate(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>Desconto</h3>
+
+          <label className={styles.checkboxLine}>
+            <input
+              type='checkbox'
+              checked={noDiscount}
+              onChange={(e) => setNoDiscount(e.target.checked)}
+            />
+            Sem desconto
+          </label>
+
+          {renderDiscountBlock()}
+        </div>
+
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>Juros</h3>
+
+          <label className={styles.checkboxLine}>
+            <input
+              type='checkbox'
+              checked={noInterest}
+              onChange={(e) => setNoInterest(e.target.checked)}
+            />
+            Sem juros
+          </label>
+
+          {!noInterest && (
+            <div className={styles.field}>
+              <label htmlFor='interestValue'>
+                Valor (basis points por dia corrido — 100 = 1,00%)
+              </label>
+              <input
+                id='interestValue'
+                type='number'
+                min={0}
+                value={interestValue}
+                onChange={(e) => setInterestValue(Number(e.target.value))}
+              />
+              <span className={styles.muted}>
+                {formatBasisPoints(interestValue)} ao dia, após o vencimento
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>Multa</h3>
+
+          <label className={styles.checkboxLine}>
+            <input
+              type='checkbox'
+              checked={noFine}
+              onChange={(e) => setNoFine(e.target.checked)}
+            />
+            Sem multa
+          </label>
+
+          {!noFine && (
+            <>
+              <div className={styles.field}>
+                <label htmlFor='fineType'>Tipo</label>
+                <select
+                  id='fineType'
+                  value={fineType}
+                  onChange={(e) =>
+                    setFineType(e.target.value as 'PERCENTAGE' | 'FIXED')
+                  }
+                >
+                  <option value='PERCENTAGE'>PERCENTAGE</option>
+                  <option value='FIXED'>FIXED</option>
+                </select>
+              </div>
+
+              <div className={styles.field}>
+                <label htmlFor='fineValue'>
+                  Valor{' '}
+                  {fineType === 'FIXED'
+                    ? '(centavos)'
+                    : '(basis points — 100 = 1,00%)'}
+                </label>
+                <input
+                  id='fineValue'
+                  type='number'
+                  min={0}
+                  value={fineValue}
+                  onChange={(e) => setFineValue(Number(e.target.value))}
+                />
+                <span className={styles.muted}>
+                  {fineType === 'FIXED'
+                    ? formatCents(fineValue)
+                    : formatBasisPoints(fineValue)}
+                </span>
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>Granularidade</h3>
+
+          <label className={styles.checkboxLine}>
+            <input
+              type='checkbox'
+              checked={granularity === 'summary'}
+              onChange={(e) =>
+                setGranularity(e.target.checked ? 'summary' : 'daily')
+              }
+            />
+            Modo summary (apenas marcos relevantes)
+          </label>
+        </div>
+      </div>
+
+      <div className={styles.actions}>
+        <button
+          type='button'
+          className={styles.primaryButton}
+          onClick={() => copy(buildJsonEnvelope(), 'JSON')}
+          disabled={!!validation}
+        >
+          Copiar JSON
+        </button>
+        <button
+          type='button'
+          className={styles.secondaryButton}
+          onClick={() => copy(buildCurl(), 'cURL')}
+          disabled={!!validation}
+        >
+          Copiar como cURL
+        </button>
+        {copyStatus && (
+          <span className={styles.copyStatus} role='status'>
+            {copyStatus}
+          </span>
+        )}
+      </div>
+
+      {validation ? (
+        <p className={styles.error} role='alert'>
+          {validation}
+        </p>
+      ) : (
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th scope='col'>date</th>
+                <th scope='col'>day</th>
+                <th scope='col'>toDue</th>
+                <th scope='col'>business</th>
+                <th scope='col'>value</th>
+                <th scope='col'>discount</th>
+                <th scope='col'>interest</th>
+                <th scope='col'>fine</th>
+                <th scope='col'>total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => {
+                const rowClass =
+                  r.daysToDueDate === 0
+                    ? styles.rowDue
+                    : r.daysToDueDate < 0
+                      ? styles.rowOverdue
+                      : '';
+
+                return (
+                  <tr key={r.daysFromCreation} className={rowClass}>
+                    <td>{r.date}</td>
+                    <td>{r.daysFromCreation}</td>
+                    <td>{r.daysToDueDate}</td>
+                    <td>{r.isBusinessDay ? 'business' : 'non-bus.'}</td>
+                    <td>{formatCents(r.value)}</td>
+                    <td>{formatCents(r.discount)}</td>
+                    <td>{formatCents(r.interest)}</td>
+                    <td>{formatCents(r.fine)}</td>
+                    <td className={styles.totalCell}>
+                      {formatCents(r.total)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ChargeDiscountSimulator;

--- a/src/components/ChargeDiscountSimulator/simulate.ts
+++ b/src/components/ChargeDiscountSimulator/simulate.ts
@@ -1,0 +1,385 @@
+// Sync source: packages/openpix/scripts/api/charge/simulateChargeDiscount.ts in
+// entria/woovi monorepo. Update both files in lockstep when the calculation
+// rules change.
+
+// =====================================================================
+//                              Types
+// =====================================================================
+
+export type DiscountModality =
+  | 'FIXED_VALUE_UNTIL_SPECIFIED_DATE'
+  | 'PERCENTAGE_UNTIL_SPECIFIED_DATE'
+  | 'VALUE_PER_RUNNING_DAY_ADVANCE'
+  | 'VALUE_PER_BUSINESS_DAY_ADVANCE'
+  | 'PERCENTAGE_PER_RUNNING_DAY_ADVANCE'
+  | 'PERCENTAGE_PER_BUSINESS_DAY_ADVANCE';
+
+export type DiscountSettings =
+  | {
+      modality:
+        | 'FIXED_VALUE_UNTIL_SPECIFIED_DATE'
+        | 'PERCENTAGE_UNTIL_SPECIFIED_DATE';
+      discountFixedDate: { daysActive: number; value: number }[];
+    }
+  | {
+      modality:
+        | 'VALUE_PER_RUNNING_DAY_ADVANCE'
+        | 'VALUE_PER_BUSINESS_DAY_ADVANCE'
+        | 'PERCENTAGE_PER_RUNNING_DAY_ADVANCE'
+        | 'PERCENTAGE_PER_BUSINESS_DAY_ADVANCE';
+      value: number;
+    };
+
+export type InterestSettings = {
+  // basis points per running day (100 = 1.00%/day). Mirrors woovi's current rule.
+  value: number;
+};
+
+export type FineSettings = {
+  // For type 'PERCENTAGE': basis points (100 = 1.00%).
+  // For type 'FIXED': cents.
+  value: number;
+  type?: 'PERCENTAGE' | 'FIXED';
+};
+
+export type SimulationInput = {
+  chargeValue: number;
+  daysForDueDate: number;
+  daysAfterDueDate?: number;
+  discountSettings?: DiscountSettings;
+  interests?: InterestSettings;
+  fines?: FineSettings;
+  creationDate?: Date;
+  holidays?: string[];
+  granularity?: 'daily' | 'summary';
+};
+
+export type SimulationRow = {
+  date: string;
+  daysFromCreation: number;
+  daysToDueDate: number;
+  isBusinessDay: boolean;
+  value: number;
+  discount: number;
+  interest: number;
+  fine: number;
+  total: number;
+};
+
+// =====================================================================
+//                          Date helpers
+// =====================================================================
+
+const stripTime = (d: Date): Date =>
+  new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+
+const addDays = (d: Date, days: number): Date => {
+  const next = stripTime(d);
+
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+};
+
+const formatDate = (d: Date): string => stripTime(d).toISOString().slice(0, 10);
+
+const isWeekend = (d: Date): boolean => {
+  const day = d.getUTCDay();
+
+  return day === 0 || day === 6;
+};
+
+const isBusinessDay = (d: Date, holidays: Set<string>): boolean =>
+  !isWeekend(d) && !holidays.has(formatDate(d));
+
+const businessDaysBetween = (
+  from: Date,
+  to: Date,
+  holidays: Set<string>,
+): number => {
+  const start = stripTime(from);
+
+  const end = stripTime(to);
+
+  if (start.getTime() >= end.getTime()) {
+    return 0;
+  }
+  let count = 0;
+
+  let cursor = addDays(start, 1);
+
+  while (cursor.getTime() <= end.getTime()) {
+    if (isBusinessDay(cursor, holidays)) {
+      count++;
+    }
+    cursor = addDays(cursor, 1);
+  }
+  return count;
+};
+
+// =====================================================================
+//                  Default Brazilian banking holidays
+// =====================================================================
+
+/**
+ * Brazilian national banking holidays for 2026 and 2027. Update this list
+ * yearly. Override via `input.holidays` for staging/testing or future years.
+ *
+ * Sources:
+ * - Fixed feasts: BACEN domain.
+ * - Movable feasts (Carnaval/Cinzas/Sexta-Santa/Corpus Christi): derived from
+ *   Easter Sunday on the year (computus): 2026 = 5-Apr; 2027 = 28-Mar.
+ */
+export const DEFAULT_BR_BANKING_HOLIDAYS: string[] = [
+  // 2026
+  '2026-01-01', // Confraternização Universal
+  '2026-02-16', // Carnaval (segunda)
+  '2026-02-17', // Carnaval (terça)
+  '2026-02-18', // Quarta-feira de Cinzas (até 12h)
+  '2026-04-03', // Sexta-Feira Santa
+  '2026-04-21', // Tiradentes
+  '2026-05-01', // Dia do Trabalho
+  '2026-06-04', // Corpus Christi
+  '2026-09-07', // Independência
+  '2026-10-12', // NS Aparecida
+  '2026-11-02', // Finados
+  '2026-11-15', // Proclamação da República (cai dom)
+  '2026-11-20', // Consciência Negra
+  '2026-12-25', // Natal
+  // 2027
+  '2027-01-01',
+  '2027-02-08',
+  '2027-02-09',
+  '2027-02-10',
+  '2027-03-26',
+  '2027-04-21',
+  '2027-05-01',
+  '2027-05-27',
+  '2027-09-07',
+  '2027-10-12',
+  '2027-11-02',
+  '2027-11-15',
+  '2027-11-20',
+  '2027-12-25',
+];
+
+// =====================================================================
+//                      Discount per day calculation
+// =====================================================================
+
+const calculateDiscountForDay = (
+  input: SimulationInput,
+  dayIndex: number,
+  daysForDueDate: number,
+  currentDate: Date,
+  dueDate: Date,
+  holidays: Set<string>,
+): number => {
+  if (!input.discountSettings) {
+    return 0;
+  }
+  if (dayIndex >= daysForDueDate) {
+    // No discount on the due date itself or later.
+    return 0;
+  }
+
+  const ds = input.discountSettings;
+
+  const original = input.chargeValue;
+
+  switch (ds.modality) {
+    case 'FIXED_VALUE_UNTIL_SPECIFIED_DATE': {
+      const items = ds.discountFixedDate ?? [];
+
+      const valid = items.filter((it) => dayIndex <= it.daysActive);
+
+      if (valid.length === 0) {
+        return 0;
+      }
+      return Math.max(...valid.map((it) => it.value));
+    }
+
+    case 'PERCENTAGE_UNTIL_SPECIFIED_DATE': {
+      const items = ds.discountFixedDate ?? [];
+
+      const valid = items.filter((it) => dayIndex <= it.daysActive);
+
+      if (valid.length === 0) {
+        return 0;
+      }
+      return Math.max(
+        ...valid.map((it) => Math.round((it.value / 10000) * original)),
+      );
+    }
+
+    case 'VALUE_PER_RUNNING_DAY_ADVANCE': {
+      const daysAhead = daysForDueDate - dayIndex;
+
+      return ds.value * daysAhead;
+    }
+
+    case 'VALUE_PER_BUSINESS_DAY_ADVANCE': {
+      const businessDays = businessDaysBetween(currentDate, dueDate, holidays);
+
+      return ds.value * businessDays;
+    }
+
+    case 'PERCENTAGE_PER_RUNNING_DAY_ADVANCE': {
+      const daysAhead = daysForDueDate - dayIndex;
+
+      return Math.round((ds.value / 10000) * original * daysAhead);
+    }
+
+    case 'PERCENTAGE_PER_BUSINESS_DAY_ADVANCE': {
+      const businessDays = businessDaysBetween(currentDate, dueDate, holidays);
+
+      return Math.round((ds.value / 10000) * original * businessDays);
+    }
+
+    default:
+      return 0;
+  }
+};
+
+const calculateInterestForDay = (
+  input: SimulationInput,
+  dayIndex: number,
+  daysForDueDate: number,
+): number => {
+  if (!input.interests) {
+    return 0;
+  }
+  const daysAfterDue = dayIndex - daysForDueDate;
+
+  if (daysAfterDue <= 0) {
+    return 0;
+  }
+  // Daily percentage rule: (basis_points / 10000) * chargeValue * daysAfterDue
+  return Math.round(
+    (input.interests.value / 10000) * input.chargeValue * daysAfterDue,
+  );
+};
+
+const calculateFineForDay = (
+  input: SimulationInput,
+  dayIndex: number,
+  daysForDueDate: number,
+): number => {
+  if (!input.fines) {
+    return 0;
+  }
+  if (dayIndex <= daysForDueDate) {
+    return 0;
+  }
+  if (input.fines.type === 'FIXED') {
+    return input.fines.value;
+  }
+  // Default and PERCENTAGE: basis points × chargeValue, applied once.
+  return Math.round((input.fines.value / 10000) * input.chargeValue);
+};
+
+// =====================================================================
+//                          Main simulator
+// =====================================================================
+
+export const simulateChargeDiscount = (
+  input: SimulationInput,
+): SimulationRow[] => {
+  if (input.chargeValue <= 0) {
+    throw new Error('chargeValue must be positive (in cents).');
+  }
+  if (input.daysForDueDate <= 0) {
+    throw new Error('daysForDueDate must be positive.');
+  }
+
+  const daysAfterDueDate = input.daysAfterDueDate ?? 15;
+
+  const creationDate = stripTime(input.creationDate ?? new Date());
+
+  const dueDate = addDays(creationDate, input.daysForDueDate);
+
+  const holidays = new Set<string>(
+    input.holidays ?? DEFAULT_BR_BANKING_HOLIDAYS,
+  );
+
+  const granularity = input.granularity ?? 'daily';
+
+  const lastDayIndex = input.daysForDueDate + daysAfterDueDate;
+
+  const rows: SimulationRow[] = [];
+
+  for (let dayIndex = 0; dayIndex <= lastDayIndex; dayIndex++) {
+    const currentDate = addDays(creationDate, dayIndex);
+
+    const discount = calculateDiscountForDay(
+      input,
+      dayIndex,
+      input.daysForDueDate,
+      currentDate,
+      dueDate,
+      holidays,
+    );
+
+    const interest = calculateInterestForDay(
+      input,
+      dayIndex,
+      input.daysForDueDate,
+    );
+
+    const fine = calculateFineForDay(input, dayIndex, input.daysForDueDate);
+
+    rows.push({
+      date: formatDate(currentDate),
+      daysFromCreation: dayIndex,
+      daysToDueDate: input.daysForDueDate - dayIndex,
+      isBusinessDay: isBusinessDay(currentDate, holidays),
+      value: input.chargeValue,
+      discount,
+      interest,
+      fine,
+      total: input.chargeValue - discount + interest + fine,
+    });
+  }
+
+  if (granularity === 'summary') {
+    return summarize(rows, input.daysForDueDate);
+  }
+
+  return rows;
+};
+
+const summarize = (
+  rows: SimulationRow[],
+  daysForDueDate: number,
+): SimulationRow[] => {
+  const out: SimulationRow[] = [];
+
+  const isMilestone = (idx: number, row: SimulationRow): boolean => {
+    if (idx === 0) {
+      return true;
+    }
+    if (idx === rows.length - 1) {
+      return true;
+    }
+    if (row.daysFromCreation === daysForDueDate) {
+      return true;
+    }
+    if (row.daysFromCreation === daysForDueDate + 1) {
+      return true;
+    }
+    const prev = rows[idx - 1];
+
+    return (
+      row.discount !== prev.discount ||
+      row.interest !== prev.interest ||
+      row.fine !== prev.fine
+    );
+  };
+
+  rows.forEach((row, idx) => {
+    if (isMilestone(idx, row)) {
+      out.push(row);
+    }
+  });
+
+  return out;
+};

--- a/src/components/ChargeDiscountSimulator/styles.module.css
+++ b/src/components/ChargeDiscountSimulator/styles.module.css
@@ -1,0 +1,243 @@
+.simulator {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+.formGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.section {
+  background: var(--ifm-card-background-color, var(--ifm-background-surface-color));
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sectionTitle {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0 0 4px;
+  color: var(--ifm-color-emphasis-900);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.field input,
+.field select {
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  background: var(--ifm-background-color);
+  color: var(--ifm-color-emphasis-900);
+  box-sizing: border-box;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: -1px;
+  border-color: var(--ifm-color-primary);
+}
+
+.checkboxLine {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-800);
+  cursor: pointer;
+}
+
+.checkboxLine input {
+  margin: 0;
+}
+
+.muted {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+.fixedDateGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fixedDateHeader,
+.fixedDateRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto;
+  gap: 6px;
+  align-items: center;
+  font-size: 0.8rem;
+}
+
+.fixedDateHeader {
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.fixedDateRow input {
+  width: 100%;
+  padding: 4px 6px;
+  font-size: 0.85rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+  background: var(--ifm-background-color);
+  box-sizing: border-box;
+}
+
+.iconButton {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  color: var(--ifm-color-emphasis-800);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.iconButton:hover:not(:disabled) {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.iconButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.primaryButton,
+.secondaryButton {
+  padding: 8px 14px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  font-family: inherit;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.primaryButton {
+  background: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-contrast-foreground, #fff);
+  border-color: var(--ifm-color-primary);
+}
+
+.primaryButton:hover:not(:disabled) {
+  background: var(--ifm-color-primary-dark);
+  border-color: var(--ifm-color-primary-dark);
+}
+
+.secondaryButton {
+  background: var(--ifm-background-color);
+  color: var(--ifm-color-emphasis-900);
+  border-color: var(--ifm-color-emphasis-300);
+}
+
+.secondaryButton:hover:not(:disabled) {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.primaryButton:disabled,
+.secondaryButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.copyStatus {
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.error {
+  color: var(--ifm-color-danger-darker, #b22222);
+  background: var(--ifm-color-danger-contrast-background, #fff5f5);
+  border: 1px solid var(--ifm-color-danger-dark, #c53030);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.tableWrap {
+  overflow-x: auto;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.table th,
+.table td {
+  padding: 6px 10px;
+  text-align: left;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.table th {
+  background: var(--ifm-color-emphasis-100);
+  font-weight: 600;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.totalCell {
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-900);
+}
+
+.rowDue {
+  background: var(--ifm-color-primary-contrast-background, rgba(3, 214, 157, 0.12));
+  font-weight: 600;
+}
+
+.rowOverdue {
+  background: var(--ifm-color-danger-contrast-background, rgba(220, 53, 69, 0.05));
+}
+
+@media (max-width: 600px) {
+  .formGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,5 @@
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+
+  export default classes;
+}


### PR DESCRIPTION
## Summary

- Adds `/docs/charge/discount-simulator` (pt-BR + en) with an interactive,
  client-side React simulator for the six BACEN COBV discount modalities.
- The simulator mirrors the CLI script
  `packages/openpix/scripts/api/charge/simulateChargeDiscount.ts` from the
  woovi monorepo — `simulate.ts` is a manual copy of the pure logic
  (types + helpers + `simulateChargeDiscount` + default BR holidays) and
  carries a header reminder to update both files in lockstep.
- Recálculo é reativo (`useMemo`); inclui modos `daily` / `summary`,
  validação inline, e botões para copiar o envelope JSON
  (`{modality, modalityNumber, input, rows}`) ou um `curl` pronto para
  `POST /api/v1/charge`.

## Files

- `docs/charge/discount-simulator.mdx`
- `i18n/en/docusaurus-plugin-content-docs/current/charge/discount-simulator.mdx`
- `src/components/ChargeDiscountSimulator/ChargeDiscountSimulator.tsx`
- `src/components/ChargeDiscountSimulator/simulate.ts`
- `src/components/ChargeDiscountSimulator/styles.module.css`
- `src/global.d.ts` (ambient declaration for `*.module.css` imports)

## Notas

- Sem dependências novas. Cálculo 100% no browser, nenhuma chamada à API.
- O cURL gerado usa `<APP_ID>` e `<CORRELATION_ID>` como placeholders;
  shape conferido contra `chargePost.api.yml` no monorepo.
- Strings internas do componente ainda são pt-BR fixas (i18n da UI fica
  como dívida — o MDX em inglês traz uma nota de rodapé).

## Test plan

- [ ] `pnpm start` e abrir `/docs/charge/discount-simulator` (pt-BR)
- [ ] Trocar entre as 6 modalidades — bloco de desconto adapta
- [ ] Editar valores → tabela recalcula em tempo real
- [ ] Toggle "modo summary" reduz para marcos relevantes
- [ ] "Copiar JSON" produz envelope idêntico ao `--out` do CLI
- [ ] "Copiar como cURL" gera body válido para `POST /api/v1/charge`
- [ ] Locale `en` em `/en/docs/charge/discount-simulator` renderiza igual
- [ ] Mobile (largura < 600px): form em coluna única, tabela com scroll horizontal

🤖 Generated with [Claude Code](https://claude.com/claude-code)