### PR TITLE
chore: gitignore .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ junit.xml
 .yarnrc
 yarn.lock
 woovi-agents
+.mcp.json


### PR DESCRIPTION
Adds `.mcp.json` to `.gitignore` so local MCP server configs (which often contain API tokens for Grafana, Kibana, Metabase, Chatwoot, etc.) are not accidentally committed.

Where applicable, also untracks any previously-committed `.mcp.json` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)