### PR TITLE
docs(account-limits): add API docs and updated swagger for limitsGet

### DIFF
--- a/docs/account-limits/_category_.json
+++ b/docs/account-limits/_category_.json
@@ -1,0 +1,12 @@
+{
+  "label": "API Account Limits",
+  "collapsible": true,
+  "collapsed": false,
+  "link": {
+    "type": "generated-index",
+    "title": "API Account Limits"
+  },
+  "customProps": {
+    "description": "Documentação da API pública de Account Limits para BaaS"
+  }
+}

--- a/docs/account-limits/api-getting-started.mdx
+++ b/docs/account-limits/api-getting-started.mdx
@@ -1,0 +1,111 @@
+---
+id: account-limits-api-getting-started
+title: Primeiros passos com a API de Account Limits
+tags:
+  - api
+  - account-limits
+  - baas
+---
+
+Este documento irá ajudá-lo a começar a utilizar a API pública de Account Limits.
+
+## Criando uma nova chave de API
+
+O primeiro passo para começar a integrar com a API é criar uma nova chave de API.
+
+### Passo 1 - Criar um novo aplicativo
+
+Vá para `Api/Plugins` na barra lateral e clique em `Nova API/Plugin`.
+
+:::caution
+Caso você não esteja visualizando o sidebar API/Plugins é necessário ter a permissão correta, veja com o admin da sua empresa.
+:::
+
+### Passo 2 - Nome da integração
+
+Dentro da tela de criação, coloque um nome para a integração e selecione `API` para integrações backend.
+
+### Passo 3 - Criando a chave
+
+Clique em `Salvar` para criar a nova chave de API.
+
+### Passo 4 - Fator de autenticação
+
+Para que a API possa ser utilizada, é necessário colocar um fator duplo de autenticação para garantir maior segurança na geração de chaves.
+
+### Passo 5 - Copiando as credenciais
+
+Após criar a nova chave, copie o **clientId** e o **clientSecret** para utilizar em suas integrações.
+
+## Como utilizar a API
+
+Todas as `requests` e `responses` da API usam o formato JSON.
+
+A autenticação é feita via **HTTP Basic Auth** usando o `clientId` como usuário e o `clientSecret` como senha. Codifique a combinação `clientId:clientSecret` em base64 e envie no header `Authorization`.
+
+```json
+{
+  "Authorization": "Basic <base64(clientId:clientSecret)>"
+}
+```
+
+Exemplo:
+
+```sh
+curl -X GET https://api.woovi.com/api/v1/limits/SEU_ACCOUNT_ID \
+  -H "Content-Type: application/json" \
+  -u "SEU_CLIENT_ID:SEU_CLIENT_SECRET"
+```
+
+### Requisitos
+
+- A empresa deve possuir a feature **ACCOUNT_LIMITS_PUBLIC_API** habilitada
+- A aplicação deve possuir o scope **`ACCOUNT_LIMITS_GET`**
+
+## Restrições de API
+
+- Todas as requisições devem ser criptografadas usando `https`
+- As credenciais de API são extremamente poderosas e devem ser armazenadas com cuidado extra
+- Não compartilhe `clientId`/`clientSecret` com terceiros
+- Não reutilize chaves entre ambientes
+- Apenas gere chaves quando for necessário
+- Desative chaves não utilizadas
+
+## Erros de autenticação
+
+Pode ocorrer de você receber uma resposta com o HTTP Status `401`, indicando credenciais ausentes, inválidas ou em formato incorreto. O envelope segue o padrão público da Woovi:
+
+```json
+{
+  "data": null,
+  "errors": [{ "message": "Invalid appID" }]
+}
+```
+
+Caso sua aplicação não tenha o scope necessário, você receberá HTTP Status `403`:
+
+```json
+{
+  "error": "Application does not have required scope: ACCOUNT_LIMITS_GET"
+}
+```
+
+Caso a empresa não tenha a feature `ACCOUNT_LIMITS_PUBLIC_API` habilitada, você receberá HTTP Status `403`:
+
+```json
+{
+  "error": "API not allowed"
+}
+```
+
+Caso as credenciais sejam inválidas, é recomendado gerar um novo par de `clientId`/`clientSecret` da sua aplicação e adicionar novamente em seu sistema.
+
+## URL Base
+
+| Ambiente | URL |
+|----------|-----|
+| Produção | `https://api.woovi.com/api/v1/limits` |
+
+:::tip Referência completa
+Para o schema, parâmetros e exemplos interativos do endpoint, veja a [API Reference](https://developers.woovi.com/api#tag/account-limits/GET/api/v1/limits/{accountId}).
+:::

--- a/docs/account-limits/api-limits-get.mdx
+++ b/docs/account-limits/api-limits-get.mdx
@@ -1,0 +1,163 @@
+---
+id: account-limits-api-limits-get
+title: Como consultar os limites de uma conta via API?
+tags:
+  - api
+  - account-limits
+  - baas
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Para consultar os limites configurados em uma conta bancária do merchant, utilize o _endpoint_ `GET /api/v1/limits/{accountId}`.
+
+O endpoint retorna o conjunto mais recente de limites configurados para a conta, contendo apenas os campos públicos — campos internos são filtrados antes da resposta.
+
+:::info
+Antes de usar este endpoint, garanta que sua empresa tenha a feature **`ACCOUNT_LIMITS_PUBLIC_API`** habilitada e que sua aplicação possua o scope **`ACCOUNT_LIMITS_GET`**. Veja [Primeiros passos com a API de Account Limits](./api-getting-started.mdx) para detalhes.
+:::
+
+:::tip Referência completa
+Para o schema, parâmetros e exemplos interativos, veja a [API Reference](https://developers.woovi.com/api#tag/account-limits/GET/api/v1/limits/{accountId}).
+:::
+
+## Parâmetros
+
+### Path
+
+- **`accountId`** _(obrigatório)_: Identificador (`ObjectId`) da conta bancária da empresa para a qual os limites serão retornados.
+
+## Exemplo de resposta
+
+Após efetuar a requisição, se tudo ocorreu bem, o _status code_ da requisição será `200` e o `body` da resposta retornará o objeto `limits` com os campos públicos:
+
+```json
+{
+  "limits": {
+    "pixDayLimit": 4000000,
+    "pixNightLimit": 100000,
+    "pixOutSameHolderDayLimit": 4000000,
+    "pixOutDifferentHolderDayLimit": 4000000,
+    "pixOutSameHolderNightLimit": 100000,
+    "pixOutDifferentHolderNightLimit": 100000,
+    "pixInSameHolderDayLimit": 100000000,
+    "pixInDifferentHolderDayLimit": 100000000,
+    "pixInSameHolderNightLimit": 100000000,
+    "pixInDifferentHolderNightLimit": 100000000,
+    "dayStartAt": "06:00",
+    "nightStartAt": "20:00",
+    "boletoEmissionLimit": 200,
+    "boletoMaximumValueLimit": 1000000
+  }
+}
+```
+
+:::info
+Todos os valores monetários são expressos em **centavos**. Os horários `dayStartAt`/`nightStartAt` estão no formato `HH:mm`.
+:::
+
+## Campos da resposta
+
+| Campo | Tipo | Descrição |
+|-------|------|-----------|
+| `pixDayLimit` | number | Limite total diário Pix (centavos) |
+| `pixNightLimit` | number | Limite total noturno Pix (centavos) |
+| `pixOutSameHolderDayLimit` | number | Limite diário Pix saída mesmo titular (centavos) |
+| `pixOutDifferentHolderDayLimit` | number | Limite diário Pix saída titulares distintos (centavos) |
+| `pixOutSameHolderNightLimit` | number | Limite noturno Pix saída mesmo titular (centavos) |
+| `pixOutDifferentHolderNightLimit` | number | Limite noturno Pix saída titulares distintos (centavos) |
+| `pixInSameHolderDayLimit` | number | Limite diário Pix entrada mesmo titular (centavos) |
+| `pixInDifferentHolderDayLimit` | number | Limite diário Pix entrada titulares distintos (centavos) |
+| `pixInSameHolderNightLimit` | number | Limite noturno Pix entrada mesmo titular (centavos) |
+| `pixInDifferentHolderNightLimit` | number | Limite noturno Pix entrada titulares distintos (centavos) |
+| `dayStartAt` | string | Início da janela diurna (`HH:mm`) |
+| `nightStartAt` | string | Início da janela noturna (`HH:mm`) |
+| `boletoEmissionLimit` | number | Máximo de boletos emitidos por dia |
+| `boletoMaximumValueLimit` | number | Valor máximo por boleto emitido (centavos) |
+
+## Códigos de resposta
+
+| Status | Descrição |
+|--------|-----------|
+| `200` | Limites retornados com sucesso |
+| `400` | `accountId` não é um `ObjectId` válido |
+| `401` | Credenciais ausentes, malformadas ou inválidas |
+| `403` | Aplicação sem o scope `ACCOUNT_LIMITS_GET` ou empresa sem a feature `ACCOUNT_LIMITS_PUBLIC_API` |
+| `404` | Conta não pertence à empresa autenticada, ou nenhum limite configurado para a conta |
+
+### Exemplos de erro
+
+```json
+{
+  "error": "Account ID is invalid"
+}
+```
+
+```json
+{
+  "data": null,
+  "errors": [{ "message": "Invalid appID" }]
+}
+```
+
+```json
+{
+  "error": "Application does not have required scope: ACCOUNT_LIMITS_GET"
+}
+```
+
+```json
+{
+  "error": "API not allowed"
+}
+```
+
+```json
+{
+  "error": "Account not found"
+}
+```
+
+```json
+{
+  "error": "No limits configured for this account"
+}
+```
+
+## Exemplos em código
+
+<Tabs>
+  <TabItem value="shell-curl" label="Shell + cURL" default>
+
+```sh
+curl 'https://api.woovi.com/api/v1/limits/SEU_ACCOUNT_ID' -X GET \
+    -H "Accept: application/json" \
+    -u "SEU_CLIENT_ID:SEU_CLIENT_SECRET"
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript + Fetch">
+
+```js
+const clientId = 'SEU_CLIENT_ID';
+const clientSecret = 'SEU_CLIENT_SECRET';
+const accountId = 'SEU_ACCOUNT_ID';
+
+const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+
+const response = await fetch(`https://api.woovi.com/api/v1/limits/${accountId}`, {
+  method: 'GET',
+  headers: {
+    'Authorization': `Basic ${credentials}`,
+  },
+});
+
+const data = await response.json();
+
+console.log(data.limits.pixDayLimit);
+// 4000000
+```
+
+  </TabItem>
+</Tabs>

--- a/src/swaggers/woovi.yml
+++ b/src/swaggers/woovi.yml
@@ -8122,6 +8122,250 @@ paths:
             response = http.request(request)
 
             puts response.read_body
+  /api/v1/limits/{accountId}:
+    get:
+      tags:
+        - account limits
+      summary: Get account limits
+      description: >
+        Retrieves the most recent account limits configured for a given bank
+        account.
+
+        Only the public-safe fields are returned; internal-only fields are
+        stripped from the response.
+      x-required-scope: ACCOUNT_LIMITS_GET
+      security:
+        - AppID:
+            - ACCOUNT_LIMITS_GET
+      parameters:
+        - name: accountId
+          in: path
+          description: >-
+            Bank account identifier (ObjectId) for which limits should be
+            returned
+          required: true
+          schema:
+            type: string
+          examples:
+            accountId:
+              value: 65f1c2e9a1b2c3d4e5f60718
+      responses:
+        '200':
+          description: Account limits returned successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  limits:
+                    $ref: '#/components/schemas/AccountLimit'
+                example:
+                  limits:
+                    pixDayLimit: 4000000
+                    pixNightLimit: 100000
+                    pixOutSameHolderDayLimit: 4000000
+                    pixOutDifferentHolderDayLimit: 4000000
+                    pixOutSameHolderNightLimit: 100000
+                    pixOutDifferentHolderNightLimit: 100000
+                    pixInSameHolderDayLimit: 100000000
+                    pixInDifferentHolderDayLimit: 100000000
+                    pixInSameHolderNightLimit: 100000000
+                    pixInDifferentHolderNightLimit: 100000000
+                    dayStartAt: '06:00'
+                    nightStartAt: '20:00'
+                    boletoEmissionLimit: 200
+                    boletoMaximumValueLimit: 1000000
+        '400':
+          description: Invalid account identifier
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+              example:
+                error: Account ID is invalid
+        '401':
+          description: Missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    nullable: true
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        message:
+                          type: string
+              example:
+                data: null
+                errors:
+                  - message: Invalid appID
+        '403':
+          description: >-
+            Application is missing the required scope or the company does not
+            have the public limits API enabled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+              examples:
+                MissingScope:
+                  value:
+                    error: >-
+                      Application does not have required scope:
+                      ACCOUNT_LIMITS_GET
+                FeatureDisabled:
+                  value:
+                    error: API not allowed
+        '404':
+          description: >-
+            Account does not belong to the requesting company or has no limit
+            configured
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+              examples:
+                AccountNotFound:
+                  value:
+                    error: Account not found
+                NoLimits:
+                  value:
+                    error: No limits configured for this account
+      x-codeSamples:
+        - lang: Node + Native
+          source: |-
+            const http = require('https');
+
+            const options = {
+              method: 'GET',
+              hostname: 'api.woovi.com',
+              port: null,
+              path: '/api/v1/limits/65f1c2e9a1b2c3d4e5f60718',
+              headers: {
+                Authorization: 'Bearer REPLACE_BEARER_TOKEN'
+              }
+            };
+
+            const req = http.request(options, function (res) {
+              const chunks = [];
+
+              res.on('data', function (chunk) {
+                chunks.push(chunk);
+              });
+
+              res.on('end', function () {
+                const body = Buffer.concat(chunks);
+                console.log(body.toString());
+              });
+            });
+
+            req.end();
+        - lang: Shell + Curl
+          source: |-
+            curl --request GET \
+              --url https://api.woovi.com/api/v1/limits/65f1c2e9a1b2c3d4e5f60718 \
+              --header 'Authorization: Bearer REPLACE_BEARER_TOKEN'
+        - lang: Php + Curl
+          source: |-
+            <?php
+
+            $curl = curl_init();
+
+            curl_setopt_array($curl, [
+              CURLOPT_URL => "https://api.woovi.com/api/v1/limits/65f1c2e9a1b2c3d4e5f60718",
+              CURLOPT_RETURNTRANSFER => true,
+              CURLOPT_ENCODING => "",
+              CURLOPT_MAXREDIRS => 10,
+              CURLOPT_TIMEOUT => 30,
+              CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+              CURLOPT_CUSTOMREQUEST => "GET",
+              CURLOPT_HTTPHEADER => [
+                "Authorization: Bearer REPLACE_BEARER_TOKEN"
+              ],
+            ]);
+
+            $response = curl_exec($curl);
+            $err = curl_error($curl);
+
+            curl_close($curl);
+
+            if ($err) {
+              echo "cURL Error #:" . $err;
+            } else {
+              echo $response;
+            }
+        - lang: Python + Python3
+          source: >-
+            import http.client
+
+
+            conn = http.client.HTTPSConnection("api.woovi.com")
+
+
+            headers = { 'Authorization': "Bearer REPLACE_BEARER_TOKEN" }
+
+
+            conn.request("GET", "/api/v1/limits/65f1c2e9a1b2c3d4e5f60718",
+            headers=headers)
+
+
+            res = conn.getresponse()
+
+            data = res.read()
+
+
+            print(data.decode("utf-8"))
+        - lang: Go + Native
+          source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/limits/65f1c2e9a1b2c3d4e5f60718\"\n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+        - lang: Java + Okhttp
+          source: |-
+            OkHttpClient client = new OkHttpClient();
+
+            Request request = new Request.Builder()
+              .url("https://api.woovi.com/api/v1/limits/65f1c2e9a1b2c3d4e5f60718")
+              .get()
+              .addHeader("Authorization", "Bearer REPLACE_BEARER_TOKEN")
+              .build();
+
+            Response response = client.newCall(request).execute();
+        - lang: Ruby + Native
+          source: >-
+            require 'uri'
+
+            require 'net/http'
+
+
+            url =
+            URI("https://api.woovi.com/api/v1/limits/65f1c2e9a1b2c3d4e5f60718")
+
+
+            http = Net::HTTP.new(url.host, url.port)
+
+            http.use_ssl = true
+
+
+            request = Net::HTTP::Get.new(url)
+
+            request["Authorization"] = 'Bearer REPLACE_BEARER_TOKEN'
+
+
+            response = http.request(request)
+
+            puts response.read_body
   /api/v1/partner/application:
     post:
       tags:
@@ -18388,6 +18632,69 @@ components:
                   type:
                     type: string
                     example: BR:CPF
+    AccountLimit:
+      type: object
+      properties:
+        pixDayLimit:
+          type: number
+          description: Pix day total limit in cents
+        pixNightLimit:
+          type: number
+          description: Pix night total limit in cents
+        pixOutSameHolderDayLimit:
+          type: number
+          description: >-
+            Pix outbound day limit for transfers between same-holder accounts
+            (cents)
+        pixOutDifferentHolderDayLimit:
+          type: number
+          description: >-
+            Pix outbound day limit for transfers between different-holder
+            accounts (cents)
+        pixOutSameHolderNightLimit:
+          type: number
+          description: >-
+            Pix outbound night limit for transfers between same-holder accounts
+            (cents)
+        pixOutDifferentHolderNightLimit:
+          type: number
+          description: >-
+            Pix outbound night limit for transfers between different-holder
+            accounts (cents)
+        pixInSameHolderDayLimit:
+          type: number
+          description: >-
+            Pix inbound day limit for transfers between same-holder accounts
+            (cents)
+        pixInDifferentHolderDayLimit:
+          type: number
+          description: >-
+            Pix inbound day limit for transfers between different-holder
+            accounts (cents)
+        pixInSameHolderNightLimit:
+          type: number
+          description: >-
+            Pix inbound night limit for transfers between same-holder accounts
+            (cents)
+        pixInDifferentHolderNightLimit:
+          type: number
+          description: >-
+            Pix inbound night limit for transfers between different-holder
+            accounts (cents)
+        dayStartAt:
+          type: string
+          description: Start time of the day window (HH:mm)
+          example: '06:00'
+        nightStartAt:
+          type: string
+          description: Start time of the night window (HH:mm)
+          example: '20:00'
+        boletoEmissionLimit:
+          type: number
+          description: Maximum number of boletos that can be emitted per day
+        boletoMaximumValueLimit:
+          type: number
+          description: Maximum value (in cents) allowed per boleto emission
     ApplicationEnumTypePayload:
       type: string
       description: >-
@@ -19910,6 +20217,9 @@ tags:
       Endpoint to manage Dispute
   - name: kyc
     description: Endpoints for KYC onboarding
+  - name: account limits
+    description: |
+      Endpoints to query account limits for a given bank account.
   - name: partner (request access)
     description: |
       Partners integrate affiliated companies.<br/>

--- a/static/swaggers/woovi.json
+++ b/static/swaggers/woovi.json
@@ -2669,6 +2669,91 @@
                     ]
                   }
                 },
+                "Charge with Discount (fixed-date modality)": {
+                  "value": {
+                    "type": "OVERDUE",
+                    "correlationID": "9134e286-6f71-427a-bf00-241681624587",
+                    "value": 1600,
+                    "comment": "good",
+                    "daysForDueDate": 10,
+                    "daysAfterDueDate": 5,
+                    "customer": {
+                      "name": "Dan",
+                      "taxID": "31324227036",
+                      "email": "email0@example.com",
+                      "phone": "5511999999999"
+                    },
+                    "discountSettings": {
+                      "modality": "FIXED_VALUE_UNTIL_SPECIFIED_DATE",
+                      "discountFixedDate": [
+                        {
+                          "daysActive": 5,
+                          "value": 100
+                        },
+                        {
+                          "daysActive": 8,
+                          "value": 50
+                        }
+                      ]
+                    }
+                  }
+                },
+                "Charge with Discount (percentage fixed-date modality)": {
+                  "value": {
+                    "type": "OVERDUE",
+                    "correlationID": "9134e286-6f71-427a-bf00-241681624588",
+                    "value": 10000,
+                    "comment": "5% off if paid in 5 days, 2% off if paid in 10 days",
+                    "daysForDueDate": 30,
+                    "daysAfterDueDate": 15,
+                    "customer": {
+                      "name": "Dan",
+                      "taxID": "31324227036",
+                      "email": "email0@example.com",
+                      "phone": "5511999999999"
+                    },
+                    "discountSettings": {
+                      "modality": "PERCENTAGE_UNTIL_SPECIFIED_DATE",
+                      "discountFixedDate": [
+                        {
+                          "daysActive": 5,
+                          "value": 500
+                        },
+                        {
+                          "daysActive": 10,
+                          "value": 200
+                        }
+                      ]
+                    }
+                  }
+                },
+                "Charge with Discount (advance-day modality)": {
+                  "value": {
+                    "type": "OVERDUE",
+                    "correlationID": "9134e286-6f71-427a-bf00-241681624589",
+                    "value": 10000,
+                    "comment": "0.10% off per running day until due",
+                    "daysForDueDate": 10,
+                    "daysAfterDueDate": 5,
+                    "customer": {
+                      "name": "Dan",
+                      "taxID": "31324227036",
+                      "email": "email0@example.com",
+                      "phone": "5511999999999"
+                    },
+                    "discountSettings": {
+                      "modality": "PERCENTAGE_PER_RUNNING_DAY_ADVANCE",
+                      "value": 10
+                    },
+                    "interests": {
+                      "value": 100
+                    },
+                    "fines": {
+                      "value": 200,
+                      "type": "PERCENTAGE"
+                    }
+                  }
+                },
                 "Charge with Split Internal Transfer": {
                   "value": {
                     "correlationID": "9134e286-6f71-427a-bf00-241681624587",
@@ -2855,31 +2940,31 @@
         "x-codeSamples": [
           {
             "lang": "Node + Native",
-            "source": "const http = require('https');\n\nconst options = {\n  method: 'POST',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/charge?return_existing=true',\n  headers: {\n    Authorization: 'Bearer REPLACE_BEARER_TOKEN',\n    'content-type': 'application/json'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.write(JSON.stringify({\n  correlationID: 'string',\n  value: 0,\n  type: 'DYNAMIC',\n  comment: 'string',\n  expiresIn: 0,\n  expiresDate: 'string',\n  dueDate: 'string',\n  customer: {\n    name: 'string',\n    email: 'string',\n    phone: 'string',\n    taxID: 'string',\n    correlationID: 'string',\n    address: {\n      zipcode: 'string',\n      street: 'string',\n      number: 'string',\n      neighborhood: 'string',\n      city: 'string',\n      state: 'string',\n      complement: 'string',\n      country: 'string'\n    }\n  },\n  ensureSameTaxID: true,\n  fixedLocation: true,\n  paymentLinkID: 'string',\n  daysForDueDate: 0,\n  daysAfterDueDate: 0,\n  interests: {value: 0, type: 'FIXED'},\n  fines: {value: 0, type: 'FIXED'},\n  discountSettings: {\n    modality: 'FIXED_VALUE_UNTIL_SPECIFIED_DATE',\n    discountFixedDate: [{daysActive: 0, value: 0}]\n  },\n  additionalInfo: [{key: 'string', value: 'string'}],\n  enableCashbackPercentage: true,\n  enableCashbackExclusivePercentage: true,\n  subaccount: 'string',\n  splits: [{value: 0, pixKey: 'string', splitType: 'SPLIT_INTERNAL_TRANSFER'}]\n}));\nreq.end();"
+            "source": "const http = require('https');\n\nconst options = {\n  method: 'POST',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/charge?return_existing=true',\n  headers: {\n    Authorization: 'Bearer REPLACE_BEARER_TOKEN',\n    'content-type': 'application/json'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.write(JSON.stringify({\n  correlationID: 'string',\n  value: 0,\n  type: 'DYNAMIC',\n  comment: 'string',\n  expiresIn: 0,\n  expiresDate: 'string',\n  dueDate: 'string',\n  customer: {\n    name: 'string',\n    email: 'string',\n    phone: 'string',\n    taxID: 'string',\n    correlationID: 'string',\n    address: {\n      zipcode: 'string',\n      street: 'string',\n      number: 'string',\n      neighborhood: 'string',\n      city: 'string',\n      state: 'string',\n      complement: 'string',\n      country: 'string'\n    }\n  },\n  ensureSameTaxID: true,\n  fixedLocation: true,\n  paymentLinkID: 'string',\n  daysForDueDate: 0,\n  daysAfterDueDate: 0,\n  interests: {value: 0, type: 'FIXED'},\n  fines: {value: 0, type: 'FIXED'},\n  discountSettings: {\n    modality: 'FIXED_VALUE_UNTIL_SPECIFIED_DATE',\n    discountFixedDate: [{daysActive: 1, value: 0}],\n    value: 1\n  },\n  additionalInfo: [{key: 'string', value: 'string'}],\n  enableCashbackPercentage: true,\n  enableCashbackExclusivePercentage: true,\n  subaccount: 'string',\n  splits: [{value: 0, pixKey: 'string', splitType: 'SPLIT_INTERNAL_TRANSFER'}]\n}));\nreq.end();"
           },
           {
             "lang": "Shell + Curl",
-            "source": "curl --request POST \\\n  --url 'https://api.woovi.com/api/v1/charge?return_existing=true' \\\n  --header 'Authorization: Bearer REPLACE_BEARER_TOKEN' \\\n  --header 'content-type: application/json' \\\n  --data '{\"correlationID\":\"string\",\"value\":0,\"type\":\"DYNAMIC\",\"comment\":\"string\",\"expiresIn\":0,\"expiresDate\":\"string\",\"dueDate\":\"string\",\"customer\":{\"name\":\"string\",\"email\":\"string\",\"phone\":\"string\",\"taxID\":\"string\",\"correlationID\":\"string\",\"address\":{\"zipcode\":\"string\",\"street\":\"string\",\"number\":\"string\",\"neighborhood\":\"string\",\"city\":\"string\",\"state\":\"string\",\"complement\":\"string\",\"country\":\"string\"}},\"ensureSameTaxID\":true,\"fixedLocation\":true,\"paymentLinkID\":\"string\",\"daysForDueDate\":0,\"daysAfterDueDate\":0,\"interests\":{\"value\":0,\"type\":\"FIXED\"},\"fines\":{\"value\":0,\"type\":\"FIXED\"},\"discountSettings\":{\"modality\":\"FIXED_VALUE_UNTIL_SPECIFIED_DATE\",\"discountFixedDate\":[{\"daysActive\":0,\"value\":0}]},\"additionalInfo\":[{\"key\":\"string\",\"value\":\"string\"}],\"enableCashbackPercentage\":true,\"enableCashbackExclusivePercentage\":true,\"subaccount\":\"string\",\"splits\":[{\"value\":0,\"pixKey\":\"string\",\"splitType\":\"SPLIT_INTERNAL_TRANSFER\"}]}'"
+            "source": "curl --request POST \\\n  --url 'https://api.woovi.com/api/v1/charge?return_existing=true' \\\n  --header 'Authorization: Bearer REPLACE_BEARER_TOKEN' \\\n  --header 'content-type: application/json' \\\n  --data '{\"correlationID\":\"string\",\"value\":0,\"type\":\"DYNAMIC\",\"comment\":\"string\",\"expiresIn\":0,\"expiresDate\":\"string\",\"dueDate\":\"string\",\"customer\":{\"name\":\"string\",\"email\":\"string\",\"phone\":\"string\",\"taxID\":\"string\",\"correlationID\":\"string\",\"address\":{\"zipcode\":\"string\",\"street\":\"string\",\"number\":\"string\",\"neighborhood\":\"string\",\"city\":\"string\",\"state\":\"string\",\"complement\":\"string\",\"country\":\"string\"}},\"ensureSameTaxID\":true,\"fixedLocation\":true,\"paymentLinkID\":\"string\",\"daysForDueDate\":0,\"daysAfterDueDate\":0,\"interests\":{\"value\":0,\"type\":\"FIXED\"},\"fines\":{\"value\":0,\"type\":\"FIXED\"},\"discountSettings\":{\"modality\":\"FIXED_VALUE_UNTIL_SPECIFIED_DATE\",\"discountFixedDate\":[{\"daysActive\":1,\"value\":0}],\"value\":1},\"additionalInfo\":[{\"key\":\"string\",\"value\":\"string\"}],\"enableCashbackPercentage\":true,\"enableCashbackExclusivePercentage\":true,\"subaccount\":\"string\",\"splits\":[{\"value\":0,\"pixKey\":\"string\",\"splitType\":\"SPLIT_INTERNAL_TRANSFER\"}]}'"
           },
           {
             "lang": "Php + Curl",
-            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/charge?return_existing=true\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"POST\",\n  CURLOPT_POSTFIELDS => json_encode([\n    'correlationID' => 'string',\n    'value' => 0,\n    'type' => 'DYNAMIC',\n    'comment' => 'string',\n    'expiresIn' => 0,\n    'expiresDate' => 'string',\n    'dueDate' => 'string',\n    'customer' => [\n        'name' => 'string',\n        'email' => 'string',\n        'phone' => 'string',\n        'taxID' => 'string',\n        'correlationID' => 'string',\n        'address' => [\n                'zipcode' => 'string',\n                'street' => 'string',\n                'number' => 'string',\n                'neighborhood' => 'string',\n                'city' => 'string',\n                'state' => 'string',\n                'complement' => 'string',\n                'country' => 'string'\n        ]\n    ],\n    'ensureSameTaxID' => null,\n    'fixedLocation' => null,\n    'paymentLinkID' => 'string',\n    'daysForDueDate' => 0,\n    'daysAfterDueDate' => 0,\n    'interests' => [\n        'value' => 0,\n        'type' => 'FIXED'\n    ],\n    'fines' => [\n        'value' => 0,\n        'type' => 'FIXED'\n    ],\n    'discountSettings' => [\n        'modality' => 'FIXED_VALUE_UNTIL_SPECIFIED_DATE',\n        'discountFixedDate' => [\n                [\n                                'daysActive' => 0,\n                                'value' => 0\n                ]\n        ]\n    ],\n    'additionalInfo' => [\n        [\n                'key' => 'string',\n                'value' => 'string'\n        ]\n    ],\n    'enableCashbackPercentage' => null,\n    'enableCashbackExclusivePercentage' => null,\n    'subaccount' => 'string',\n    'splits' => [\n        [\n                'value' => 0,\n                'pixKey' => 'string',\n                'splitType' => 'SPLIT_INTERNAL_TRANSFER'\n        ]\n    ]\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: Bearer REPLACE_BEARER_TOKEN\",\n    \"content-type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
+            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/charge?return_existing=true\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"POST\",\n  CURLOPT_POSTFIELDS => json_encode([\n    'correlationID' => 'string',\n    'value' => 0,\n    'type' => 'DYNAMIC',\n    'comment' => 'string',\n    'expiresIn' => 0,\n    'expiresDate' => 'string',\n    'dueDate' => 'string',\n    'customer' => [\n        'name' => 'string',\n        'email' => 'string',\n        'phone' => 'string',\n        'taxID' => 'string',\n        'correlationID' => 'string',\n        'address' => [\n                'zipcode' => 'string',\n                'street' => 'string',\n                'number' => 'string',\n                'neighborhood' => 'string',\n                'city' => 'string',\n                'state' => 'string',\n                'complement' => 'string',\n                'country' => 'string'\n        ]\n    ],\n    'ensureSameTaxID' => null,\n    'fixedLocation' => null,\n    'paymentLinkID' => 'string',\n    'daysForDueDate' => 0,\n    'daysAfterDueDate' => 0,\n    'interests' => [\n        'value' => 0,\n        'type' => 'FIXED'\n    ],\n    'fines' => [\n        'value' => 0,\n        'type' => 'FIXED'\n    ],\n    'discountSettings' => [\n        'modality' => 'FIXED_VALUE_UNTIL_SPECIFIED_DATE',\n        'discountFixedDate' => [\n                [\n                                'daysActive' => 1,\n                                'value' => 0\n                ]\n        ],\n        'value' => 1\n    ],\n    'additionalInfo' => [\n        [\n                'key' => 'string',\n                'value' => 'string'\n        ]\n    ],\n    'enableCashbackPercentage' => null,\n    'enableCashbackExclusivePercentage' => null,\n    'subaccount' => 'string',\n    'splits' => [\n        [\n                'value' => 0,\n                'pixKey' => 'string',\n                'splitType' => 'SPLIT_INTERNAL_TRANSFER'\n        ]\n    ]\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: Bearer REPLACE_BEARER_TOKEN\",\n    \"content-type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
           },
           {
             "lang": "Python + Python3",
-            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\npayload = \"{\\\"correlationID\\\":\\\"string\\\",\\\"value\\\":0,\\\"type\\\":\\\"DYNAMIC\\\",\\\"comment\\\":\\\"string\\\",\\\"expiresIn\\\":0,\\\"expiresDate\\\":\\\"string\\\",\\\"dueDate\\\":\\\"string\\\",\\\"customer\\\":{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"correlationID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}},\\\"ensureSameTaxID\\\":true,\\\"fixedLocation\\\":true,\\\"paymentLinkID\\\":\\\"string\\\",\\\"daysForDueDate\\\":0,\\\"daysAfterDueDate\\\":0,\\\"interests\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"fines\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"discountSettings\\\":{\\\"modality\\\":\\\"FIXED_VALUE_UNTIL_SPECIFIED_DATE\\\",\\\"discountFixedDate\\\":[{\\\"daysActive\\\":0,\\\"value\\\":0}]},\\\"additionalInfo\\\":[{\\\"key\\\":\\\"string\\\",\\\"value\\\":\\\"string\\\"}],\\\"enableCashbackPercentage\\\":true,\\\"enableCashbackExclusivePercentage\\\":true,\\\"subaccount\\\":\\\"string\\\",\\\"splits\\\":[{\\\"value\\\":0,\\\"pixKey\\\":\\\"string\\\",\\\"splitType\\\":\\\"SPLIT_INTERNAL_TRANSFER\\\"}]}\"\n\nheaders = {\n    'Authorization': \"Bearer REPLACE_BEARER_TOKEN\",\n    'content-type': \"application/json\"\n}\n\nconn.request(\"POST\", \"/api/v1/charge?return_existing=true\", payload, headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
+            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\npayload = \"{\\\"correlationID\\\":\\\"string\\\",\\\"value\\\":0,\\\"type\\\":\\\"DYNAMIC\\\",\\\"comment\\\":\\\"string\\\",\\\"expiresIn\\\":0,\\\"expiresDate\\\":\\\"string\\\",\\\"dueDate\\\":\\\"string\\\",\\\"customer\\\":{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"correlationID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}},\\\"ensureSameTaxID\\\":true,\\\"fixedLocation\\\":true,\\\"paymentLinkID\\\":\\\"string\\\",\\\"daysForDueDate\\\":0,\\\"daysAfterDueDate\\\":0,\\\"interests\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"fines\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"discountSettings\\\":{\\\"modality\\\":\\\"FIXED_VALUE_UNTIL_SPECIFIED_DATE\\\",\\\"discountFixedDate\\\":[{\\\"daysActive\\\":1,\\\"value\\\":0}],\\\"value\\\":1},\\\"additionalInfo\\\":[{\\\"key\\\":\\\"string\\\",\\\"value\\\":\\\"string\\\"}],\\\"enableCashbackPercentage\\\":true,\\\"enableCashbackExclusivePercentage\\\":true,\\\"subaccount\\\":\\\"string\\\",\\\"splits\\\":[{\\\"value\\\":0,\\\"pixKey\\\":\\\"string\\\",\\\"splitType\\\":\\\"SPLIT_INTERNAL_TRANSFER\\\"}]}\"\n\nheaders = {\n    'Authorization': \"Bearer REPLACE_BEARER_TOKEN\",\n    'content-type': \"application/json\"\n}\n\nconn.request(\"POST\", \"/api/v1/charge?return_existing=true\", payload, headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
           },
           {
             "lang": "Go + Native",
-            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/charge?return_existing=true\"\n\n\tpayload := strings.NewReader(\"{\\\"correlationID\\\":\\\"string\\\",\\\"value\\\":0,\\\"type\\\":\\\"DYNAMIC\\\",\\\"comment\\\":\\\"string\\\",\\\"expiresIn\\\":0,\\\"expiresDate\\\":\\\"string\\\",\\\"dueDate\\\":\\\"string\\\",\\\"customer\\\":{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"correlationID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}},\\\"ensureSameTaxID\\\":true,\\\"fixedLocation\\\":true,\\\"paymentLinkID\\\":\\\"string\\\",\\\"daysForDueDate\\\":0,\\\"daysAfterDueDate\\\":0,\\\"interests\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"fines\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"discountSettings\\\":{\\\"modality\\\":\\\"FIXED_VALUE_UNTIL_SPECIFIED_DATE\\\",\\\"discountFixedDate\\\":[{\\\"daysActive\\\":0,\\\"value\\\":0}]},\\\"additionalInfo\\\":[{\\\"key\\\":\\\"string\\\",\\\"value\\\":\\\"string\\\"}],\\\"enableCashbackPercentage\\\":true,\\\"enableCashbackExclusivePercentage\\\":true,\\\"subaccount\\\":\\\"string\\\",\\\"splits\\\":[{\\\"value\\\":0,\\\"pixKey\\\":\\\"string\\\",\\\"splitType\\\":\\\"SPLIT_INTERNAL_TRANSFER\\\"}]}\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/charge?return_existing=true\"\n\n\tpayload := strings.NewReader(\"{\\\"correlationID\\\":\\\"string\\\",\\\"value\\\":0,\\\"type\\\":\\\"DYNAMIC\\\",\\\"comment\\\":\\\"string\\\",\\\"expiresIn\\\":0,\\\"expiresDate\\\":\\\"string\\\",\\\"dueDate\\\":\\\"string\\\",\\\"customer\\\":{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"correlationID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}},\\\"ensureSameTaxID\\\":true,\\\"fixedLocation\\\":true,\\\"paymentLinkID\\\":\\\"string\\\",\\\"daysForDueDate\\\":0,\\\"daysAfterDueDate\\\":0,\\\"interests\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"fines\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"discountSettings\\\":{\\\"modality\\\":\\\"FIXED_VALUE_UNTIL_SPECIFIED_DATE\\\",\\\"discountFixedDate\\\":[{\\\"daysActive\\\":1,\\\"value\\\":0}],\\\"value\\\":1},\\\"additionalInfo\\\":[{\\\"key\\\":\\\"string\\\",\\\"value\\\":\\\"string\\\"}],\\\"enableCashbackPercentage\\\":true,\\\"enableCashbackExclusivePercentage\\\":true,\\\"subaccount\\\":\\\"string\\\",\\\"splits\\\":[{\\\"value\\\":0,\\\"pixKey\\\":\\\"string\\\",\\\"splitType\\\":\\\"SPLIT_INTERNAL_TRANSFER\\\"}]}\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
           },
           {
             "lang": "Java + Okhttp",
-            "source": "OkHttpClient client = new OkHttpClient();\n\nMediaType mediaType = MediaType.parse(\"application/json\");\nRequestBody body = RequestBody.create(mediaType, \"{\\\"correlationID\\\":\\\"string\\\",\\\"value\\\":0,\\\"type\\\":\\\"DYNAMIC\\\",\\\"comment\\\":\\\"string\\\",\\\"expiresIn\\\":0,\\\"expiresDate\\\":\\\"string\\\",\\\"dueDate\\\":\\\"string\\\",\\\"customer\\\":{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"correlationID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}},\\\"ensureSameTaxID\\\":true,\\\"fixedLocation\\\":true,\\\"paymentLinkID\\\":\\\"string\\\",\\\"daysForDueDate\\\":0,\\\"daysAfterDueDate\\\":0,\\\"interests\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"fines\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"discountSettings\\\":{\\\"modality\\\":\\\"FIXED_VALUE_UNTIL_SPECIFIED_DATE\\\",\\\"discountFixedDate\\\":[{\\\"daysActive\\\":0,\\\"value\\\":0}]},\\\"additionalInfo\\\":[{\\\"key\\\":\\\"string\\\",\\\"value\\\":\\\"string\\\"}],\\\"enableCashbackPercentage\\\":true,\\\"enableCashbackExclusivePercentage\\\":true,\\\"subaccount\\\":\\\"string\\\",\\\"splits\\\":[{\\\"value\\\":0,\\\"pixKey\\\":\\\"string\\\",\\\"splitType\\\":\\\"SPLIT_INTERNAL_TRANSFER\\\"}]}\");\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/charge?return_existing=true\")\n  .post(body)\n  .addHeader(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n  .addHeader(\"content-type\", \"application/json\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
+            "source": "OkHttpClient client = new OkHttpClient();\n\nMediaType mediaType = MediaType.parse(\"application/json\");\nRequestBody body = RequestBody.create(mediaType, \"{\\\"correlationID\\\":\\\"string\\\",\\\"value\\\":0,\\\"type\\\":\\\"DYNAMIC\\\",\\\"comment\\\":\\\"string\\\",\\\"expiresIn\\\":0,\\\"expiresDate\\\":\\\"string\\\",\\\"dueDate\\\":\\\"string\\\",\\\"customer\\\":{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"correlationID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}},\\\"ensureSameTaxID\\\":true,\\\"fixedLocation\\\":true,\\\"paymentLinkID\\\":\\\"string\\\",\\\"daysForDueDate\\\":0,\\\"daysAfterDueDate\\\":0,\\\"interests\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"fines\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"discountSettings\\\":{\\\"modality\\\":\\\"FIXED_VALUE_UNTIL_SPECIFIED_DATE\\\",\\\"discountFixedDate\\\":[{\\\"daysActive\\\":1,\\\"value\\\":0}],\\\"value\\\":1},\\\"additionalInfo\\\":[{\\\"key\\\":\\\"string\\\",\\\"value\\\":\\\"string\\\"}],\\\"enableCashbackPercentage\\\":true,\\\"enableCashbackExclusivePercentage\\\":true,\\\"subaccount\\\":\\\"string\\\",\\\"splits\\\":[{\\\"value\\\":0,\\\"pixKey\\\":\\\"string\\\",\\\"splitType\\\":\\\"SPLIT_INTERNAL_TRANSFER\\\"}]}\");\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/charge?return_existing=true\")\n  .post(body)\n  .addHeader(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n  .addHeader(\"content-type\", \"application/json\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
           },
           {
             "lang": "Ruby + Native",
-            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/charge?return_existing=true\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"Authorization\"] = 'Bearer REPLACE_BEARER_TOKEN'\nrequest[\"content-type\"] = 'application/json'\nrequest.body = \"{\\\"correlationID\\\":\\\"string\\\",\\\"value\\\":0,\\\"type\\\":\\\"DYNAMIC\\\",\\\"comment\\\":\\\"string\\\",\\\"expiresIn\\\":0,\\\"expiresDate\\\":\\\"string\\\",\\\"dueDate\\\":\\\"string\\\",\\\"customer\\\":{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"correlationID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}},\\\"ensureSameTaxID\\\":true,\\\"fixedLocation\\\":true,\\\"paymentLinkID\\\":\\\"string\\\",\\\"daysForDueDate\\\":0,\\\"daysAfterDueDate\\\":0,\\\"interests\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"fines\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"discountSettings\\\":{\\\"modality\\\":\\\"FIXED_VALUE_UNTIL_SPECIFIED_DATE\\\",\\\"discountFixedDate\\\":[{\\\"daysActive\\\":0,\\\"value\\\":0}]},\\\"additionalInfo\\\":[{\\\"key\\\":\\\"string\\\",\\\"value\\\":\\\"string\\\"}],\\\"enableCashbackPercentage\\\":true,\\\"enableCashbackExclusivePercentage\\\":true,\\\"subaccount\\\":\\\"string\\\",\\\"splits\\\":[{\\\"value\\\":0,\\\"pixKey\\\":\\\"string\\\",\\\"splitType\\\":\\\"SPLIT_INTERNAL_TRANSFER\\\"}]}\"\n\nresponse = http.request(request)\nputs response.read_body"
+            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/charge?return_existing=true\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"Authorization\"] = 'Bearer REPLACE_BEARER_TOKEN'\nrequest[\"content-type\"] = 'application/json'\nrequest.body = \"{\\\"correlationID\\\":\\\"string\\\",\\\"value\\\":0,\\\"type\\\":\\\"DYNAMIC\\\",\\\"comment\\\":\\\"string\\\",\\\"expiresIn\\\":0,\\\"expiresDate\\\":\\\"string\\\",\\\"dueDate\\\":\\\"string\\\",\\\"customer\\\":{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"correlationID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}},\\\"ensureSameTaxID\\\":true,\\\"fixedLocation\\\":true,\\\"paymentLinkID\\\":\\\"string\\\",\\\"daysForDueDate\\\":0,\\\"daysAfterDueDate\\\":0,\\\"interests\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"fines\\\":{\\\"value\\\":0,\\\"type\\\":\\\"FIXED\\\"},\\\"discountSettings\\\":{\\\"modality\\\":\\\"FIXED_VALUE_UNTIL_SPECIFIED_DATE\\\",\\\"discountFixedDate\\\":[{\\\"daysActive\\\":1,\\\"value\\\":0}],\\\"value\\\":1},\\\"additionalInfo\\\":[{\\\"key\\\":\\\"string\\\",\\\"value\\\":\\\"string\\\"}],\\\"enableCashbackPercentage\\\":true,\\\"enableCashbackExclusivePercentage\\\":true,\\\"subaccount\\\":\\\"string\\\",\\\"splits\\\":[{\\\"value\\\":0,\\\"pixKey\\\":\\\"string\\\",\\\"splitType\\\":\\\"SPLIT_INTERNAL_TRANSFER\\\"}]}\"\n\nresponse = http.request(request)\nputs response.read_body"
           }
         ]
       }
@@ -6059,6 +6144,211 @@
         ]
       }
     },
+    "/api/v1/limits/{accountId}": {
+      "get": {
+        "tags": [
+          "account limits"
+        ],
+        "summary": "Get account limits",
+        "description": "Retrieves the most recent account limits configured for a given bank account.\nOnly the public-safe fields are returned; internal-only fields are stripped from the response.\n",
+        "x-required-scope": "ACCOUNT_LIMITS_GET",
+        "security": [
+          {
+            "AppID": [
+              "ACCOUNT_LIMITS_GET"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "description": "Bank account identifier (ObjectId) for which limits should be returned",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "accountId": {
+                "value": "65f1c2e9a1b2c3d4e5f60718"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account limits returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "limits": {
+                      "$ref": "#/components/schemas/AccountLimit"
+                    }
+                  },
+                  "example": {
+                    "limits": {
+                      "pixDayLimit": 4000000,
+                      "pixNightLimit": 100000,
+                      "pixOutSameHolderDayLimit": 4000000,
+                      "pixOutDifferentHolderDayLimit": 4000000,
+                      "pixOutSameHolderNightLimit": 100000,
+                      "pixOutDifferentHolderNightLimit": 100000,
+                      "pixInSameHolderDayLimit": 100000000,
+                      "pixInDifferentHolderDayLimit": 100000000,
+                      "pixInSameHolderNightLimit": 100000000,
+                      "pixInDifferentHolderNightLimit": 100000000,
+                      "dayStartAt": "06:00",
+                      "nightStartAt": "20:00",
+                      "boletoEmissionLimit": 200,
+                      "boletoMaximumValueLimit": 1000000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid account identifier",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "error": "Account ID is invalid"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "message": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": null,
+                  "errors": [
+                    {
+                      "message": "Invalid appID"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Application is missing the required scope or the company does not have the public limits API enabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "examples": {
+                  "MissingScope": {
+                    "value": {
+                      "error": "Application does not have required scope: ACCOUNT_LIMITS_GET"
+                    }
+                  },
+                  "FeatureDisabled": {
+                    "value": {
+                      "error": "API not allowed"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account does not belong to the requesting company or has no limit configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "examples": {
+                  "AccountNotFound": {
+                    "value": {
+                      "error": "Account not found"
+                    }
+                  },
+                  "NoLimits": {
+                    "value": {
+                      "error": "No limits configured for this account"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "Node + Native",
+            "source": "const http = require('https');\n\nconst options = {\n  method: 'GET',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/limits/65f1c2e9a1b2c3d4e5f60718',\n  headers: {\n    Authorization: 'Bearer REPLACE_BEARER_TOKEN'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.end();"
+          },
+          {
+            "lang": "Shell + Curl",
+            "source": "curl --request GET \\\n  --url https://api.woovi.com/api/v1/limits/65f1c2e9a1b2c3d4e5f60718 \\\n  --header 'Authorization: Bearer REPLACE_BEARER_TOKEN'"
+          },
+          {
+            "lang": "Php + Curl",
+            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/limits/65f1c2e9a1b2c3d4e5f60718\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"GET\",\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: Bearer REPLACE_BEARER_TOKEN\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
+          },
+          {
+            "lang": "Python + Python3",
+            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\nheaders = { 'Authorization': \"Bearer REPLACE_BEARER_TOKEN\" }\n\nconn.request(\"GET\", \"/api/v1/limits/65f1c2e9a1b2c3d4e5f60718\", headers=headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
+          },
+          {
+            "lang": "Go + Native",
+            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/limits/65f1c2e9a1b2c3d4e5f60718\"\n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          },
+          {
+            "lang": "Java + Okhttp",
+            "source": "OkHttpClient client = new OkHttpClient();\n\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/limits/65f1c2e9a1b2c3d4e5f60718\")\n  .get()\n  .addHeader(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
+          },
+          {
+            "lang": "Ruby + Native",
+            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/limits/65f1c2e9a1b2c3d4e5f60718\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Get.new(url)\nrequest[\"Authorization\"] = 'Bearer REPLACE_BEARER_TOKEN'\n\nresponse = http.request(request)\nputs response.read_body"
+          }
+        ]
+      }
+    },
     "/api/v1/partner/application": {
       "post": {
         "tags": [
@@ -7202,7 +7492,7 @@
             ]
           }
         ],
-        "description": "Endpoint to request a payment. Supports three payment types: Pix Key (`PIX_KEY`), QR Code (`QR_CODE`), and Manual (`MANUAL`).\n\nFor QR Code payments, the system decodes the BR Code string and extracts the destination and value automatically. After creating, use `POST /api/v1/payment/approve` with the correlationID to execute.\n",
+        "description": "Endpoint to request a payment. Supports three payment types: Pix Key (`PIX_KEY`), QR Code (`QR_CODE`), and Manual (`MANUAL`).\n\nFor QR Code payments, the system decodes the BR Code string and extracts the destination and value automatically.\n\nSet `autoApprove: true` to create and immediately approve the payment in a single call, returning the enriched response with transaction and destination data. Without this flag, the payment is created in `CREATED` status and can be approved later via `POST /api/v1/payment/approve`.\n",
         "requestBody": {
           "description": "Data to create a payment request",
           "required": true,
@@ -7210,7 +7500,20 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "$ref": "#/components/schemas/PaymentCreatePayload"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PaymentCreatePayload"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "autoApprove": {
+                        "type": "boolean",
+                        "description": "When true, creates and approves the payment in a single call returning the enriched response. Defaults to false."
+                      }
+                    }
+                  }
+                ]
               },
               "examples": {
                 "pixKey": {
@@ -7228,6 +7531,17 @@
                       "userId": "user-456",
                       "source": "mobile-app"
                     }
+                  }
+                },
+                "pixKeyAutoApprove": {
+                  "summary": "Pay via Pix Key with auto-approval",
+                  "value": {
+                    "value": 100,
+                    "destinationAlias": "c4249323-b4ca-43f2-8139-8232aab09b93",
+                    "destinationAliasType": "RANDOM",
+                    "comment": "payment comment",
+                    "correlationID": "payment-auto-approve",
+                    "autoApprove": true
                   }
                 },
                 "qrCode": {
@@ -7289,7 +7603,7 @@
         },
         "responses": {
           "200": {
-            "description": "Payment destination account information",
+            "description": "Payment created. When autoApprove is true, the payment is immediately approved and the response includes transaction and destination data.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7297,6 +7611,14 @@
                   "properties": {
                     "payment": {
                       "$ref": "#/components/schemas/Payment"
+                    },
+                    "transaction": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/PaymentTransaction"
+                    },
+                    "destination": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/PaymentDestination"
                     }
                   }
                 },
@@ -7359,6 +7681,32 @@
                         }
                       }
                     }
+                  },
+                  "autoApproved": {
+                    "summary": "Auto-approved payment response (autoApprove true)",
+                    "value": {
+                      "payment": {
+                        "value": 100,
+                        "status": "APPROVED",
+                        "destinationAlias": "c4249323-b4ca-43f2-8139-8232aab09b93",
+                        "destinationAliasType": "RANDOM",
+                        "comment": "payment comment",
+                        "correlationID": "payment1"
+                      },
+                      "transaction": {
+                        "value": 100,
+                        "endToEndId": "transaction-end-to-end-id",
+                        "time": "2023-03-20T13:14:17.000Z"
+                      },
+                      "destination": {
+                        "name": "Dan",
+                        "taxID": "31324227036",
+                        "pixKey": "c4249323-b4ca-43f2-8139-8232aab09b93",
+                        "bank": "A Bank",
+                        "branch": "1",
+                        "account": "123456"
+                      }
+                    }
                   }
                 }
               }
@@ -7383,31 +7731,31 @@
         "x-codeSamples": [
           {
             "lang": "Node + Native",
-            "source": "const http = require('https');\n\nconst options = {\n  method: 'POST',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/payment',\n  headers: {\n    Authorization: 'Bearer REPLACE_BEARER_TOKEN',\n    'content-type': 'application/json'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.write(JSON.stringify({\n  type: 'PIX_KEY',\n  value: 0,\n  destinationAlias: 'string',\n  destinationAliasType: 'CPF',\n  correlationID: 'string',\n  pixKeyEndToEndId: 'string',\n  comment: 'string',\n  metadata: {}\n}));\nreq.end();"
+            "source": "const http = require('https');\n\nconst options = {\n  method: 'POST',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/payment',\n  headers: {\n    Authorization: 'Bearer REPLACE_BEARER_TOKEN',\n    'content-type': 'application/json'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.write(JSON.stringify({\n  type: 'PIX_KEY',\n  value: 0,\n  destinationAlias: 'string',\n  destinationAliasType: 'CPF',\n  correlationID: 'string',\n  pixKeyEndToEndId: 'string',\n  comment: 'string',\n  metadata: {},\n  autoApprove: true\n}));\nreq.end();"
           },
           {
             "lang": "Shell + Curl",
-            "source": "curl --request POST \\\n  --url https://api.woovi.com/api/v1/payment \\\n  --header 'Authorization: Bearer REPLACE_BEARER_TOKEN' \\\n  --header 'content-type: application/json' \\\n  --data '{\"type\":\"PIX_KEY\",\"value\":0,\"destinationAlias\":\"string\",\"destinationAliasType\":\"CPF\",\"correlationID\":\"string\",\"pixKeyEndToEndId\":\"string\",\"comment\":\"string\",\"metadata\":{}}'"
+            "source": "curl --request POST \\\n  --url https://api.woovi.com/api/v1/payment \\\n  --header 'Authorization: Bearer REPLACE_BEARER_TOKEN' \\\n  --header 'content-type: application/json' \\\n  --data '{\"type\":\"PIX_KEY\",\"value\":0,\"destinationAlias\":\"string\",\"destinationAliasType\":\"CPF\",\"correlationID\":\"string\",\"pixKeyEndToEndId\":\"string\",\"comment\":\"string\",\"metadata\":{},\"autoApprove\":true}'"
           },
           {
             "lang": "Php + Curl",
-            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/payment\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"POST\",\n  CURLOPT_POSTFIELDS => json_encode([\n    'type' => 'PIX_KEY',\n    'value' => 0,\n    'destinationAlias' => 'string',\n    'destinationAliasType' => 'CPF',\n    'correlationID' => 'string',\n    'pixKeyEndToEndId' => 'string',\n    'comment' => 'string',\n    'metadata' => [\n        \n    ]\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: Bearer REPLACE_BEARER_TOKEN\",\n    \"content-type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
+            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/payment\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"POST\",\n  CURLOPT_POSTFIELDS => json_encode([\n    'type' => 'PIX_KEY',\n    'value' => 0,\n    'destinationAlias' => 'string',\n    'destinationAliasType' => 'CPF',\n    'correlationID' => 'string',\n    'pixKeyEndToEndId' => 'string',\n    'comment' => 'string',\n    'metadata' => [\n        \n    ],\n    'autoApprove' => null\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: Bearer REPLACE_BEARER_TOKEN\",\n    \"content-type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
           },
           {
             "lang": "Python + Python3",
-            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\npayload = \"{\\\"type\\\":\\\"PIX_KEY\\\",\\\"value\\\":0,\\\"destinationAlias\\\":\\\"string\\\",\\\"destinationAliasType\\\":\\\"CPF\\\",\\\"correlationID\\\":\\\"string\\\",\\\"pixKeyEndToEndId\\\":\\\"string\\\",\\\"comment\\\":\\\"string\\\",\\\"metadata\\\":{}}\"\n\nheaders = {\n    'Authorization': \"Bearer REPLACE_BEARER_TOKEN\",\n    'content-type': \"application/json\"\n}\n\nconn.request(\"POST\", \"/api/v1/payment\", payload, headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
+            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\npayload = \"{\\\"type\\\":\\\"PIX_KEY\\\",\\\"value\\\":0,\\\"destinationAlias\\\":\\\"string\\\",\\\"destinationAliasType\\\":\\\"CPF\\\",\\\"correlationID\\\":\\\"string\\\",\\\"pixKeyEndToEndId\\\":\\\"string\\\",\\\"comment\\\":\\\"string\\\",\\\"metadata\\\":{},\\\"autoApprove\\\":true}\"\n\nheaders = {\n    'Authorization': \"Bearer REPLACE_BEARER_TOKEN\",\n    'content-type': \"application/json\"\n}\n\nconn.request(\"POST\", \"/api/v1/payment\", payload, headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
           },
           {
             "lang": "Go + Native",
-            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/payment\"\n\n\tpayload := strings.NewReader(\"{\\\"type\\\":\\\"PIX_KEY\\\",\\\"value\\\":0,\\\"destinationAlias\\\":\\\"string\\\",\\\"destinationAliasType\\\":\\\"CPF\\\",\\\"correlationID\\\":\\\"string\\\",\\\"pixKeyEndToEndId\\\":\\\"string\\\",\\\"comment\\\":\\\"string\\\",\\\"metadata\\\":{}}\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/payment\"\n\n\tpayload := strings.NewReader(\"{\\\"type\\\":\\\"PIX_KEY\\\",\\\"value\\\":0,\\\"destinationAlias\\\":\\\"string\\\",\\\"destinationAliasType\\\":\\\"CPF\\\",\\\"correlationID\\\":\\\"string\\\",\\\"pixKeyEndToEndId\\\":\\\"string\\\",\\\"comment\\\":\\\"string\\\",\\\"metadata\\\":{},\\\"autoApprove\\\":true}\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
           },
           {
             "lang": "Java + Okhttp",
-            "source": "OkHttpClient client = new OkHttpClient();\n\nMediaType mediaType = MediaType.parse(\"application/json\");\nRequestBody body = RequestBody.create(mediaType, \"{\\\"type\\\":\\\"PIX_KEY\\\",\\\"value\\\":0,\\\"destinationAlias\\\":\\\"string\\\",\\\"destinationAliasType\\\":\\\"CPF\\\",\\\"correlationID\\\":\\\"string\\\",\\\"pixKeyEndToEndId\\\":\\\"string\\\",\\\"comment\\\":\\\"string\\\",\\\"metadata\\\":{}}\");\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/payment\")\n  .post(body)\n  .addHeader(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n  .addHeader(\"content-type\", \"application/json\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
+            "source": "OkHttpClient client = new OkHttpClient();\n\nMediaType mediaType = MediaType.parse(\"application/json\");\nRequestBody body = RequestBody.create(mediaType, \"{\\\"type\\\":\\\"PIX_KEY\\\",\\\"value\\\":0,\\\"destinationAlias\\\":\\\"string\\\",\\\"destinationAliasType\\\":\\\"CPF\\\",\\\"correlationID\\\":\\\"string\\\",\\\"pixKeyEndToEndId\\\":\\\"string\\\",\\\"comment\\\":\\\"string\\\",\\\"metadata\\\":{},\\\"autoApprove\\\":true}\");\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/payment\")\n  .post(body)\n  .addHeader(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n  .addHeader(\"content-type\", \"application/json\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
           },
           {
             "lang": "Ruby + Native",
-            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/payment\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"Authorization\"] = 'Bearer REPLACE_BEARER_TOKEN'\nrequest[\"content-type\"] = 'application/json'\nrequest.body = \"{\\\"type\\\":\\\"PIX_KEY\\\",\\\"value\\\":0,\\\"destinationAlias\\\":\\\"string\\\",\\\"destinationAliasType\\\":\\\"CPF\\\",\\\"correlationID\\\":\\\"string\\\",\\\"pixKeyEndToEndId\\\":\\\"string\\\",\\\"comment\\\":\\\"string\\\",\\\"metadata\\\":{}}\"\n\nresponse = http.request(request)\nputs response.read_body"
+            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/payment\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"Authorization\"] = 'Bearer REPLACE_BEARER_TOKEN'\nrequest[\"content-type\"] = 'application/json'\nrequest.body = \"{\\\"type\\\":\\\"PIX_KEY\\\",\\\"value\\\":0,\\\"destinationAlias\\\":\\\"string\\\",\\\"destinationAliasType\\\":\\\"CPF\\\",\\\"correlationID\\\":\\\"string\\\",\\\"pixKeyEndToEndId\\\":\\\"string\\\",\\\"comment\\\":\\\"string\\\",\\\"metadata\\\":{},\\\"autoApprove\\\":true}\"\n\nresponse = http.request(request)\nputs response.read_body"
           }
         ]
       }
@@ -13190,33 +13538,50 @@
             }
           },
           "discountSettings": {
-            "description": "Discount settings for the charge. This property is only considered for charges of type OVERDUE",
+            "description": "Discount settings for the charge. This property is only considered for charges of type OVERDUE.\n\n**How it interacts with `fines` and `interests`.** Discount only applies to payments **before** the due date (controlled by `daysForDueDate`). On or after the due date the discount is gone, and `fines` (applied once) and `interests` (accruing per day) start adding **on top of** `value`. Use the [day-by-day simulator](https://github.com/entria/woovi/blob/main/packages/openpix/scripts/api/charge/simulateChargeDiscount.ts) to preview the totals a payer sees on each day of the charge lifecycle.\n\n**Modality enum** follows the BACEN COBV (Cobrança com Vencimento) spec — see [bacen.github.io/pix-api](https://bacen.github.io/pix-api/) for the upstream reference.\n\n**Shape of the object depends on `modality`:**\n  - For `FIXED_VALUE_UNTIL_SPECIFIED_DATE` and `PERCENTAGE_UNTIL_SPECIFIED_DATE`, provide `discountFixedDate` (array of items with `daysActive` and `value`). When multiple entries match the current day (i.e. their `daysActive` window has not yet expired), the entry with the **largest** discount wins.\n  - For the four advance-day modalities (`VALUE_PER_RUNNING_DAY_ADVANCE`, `VALUE_PER_BUSINESS_DAY_ADVANCE`, `PERCENTAGE_PER_RUNNING_DAY_ADVANCE`, `PERCENTAGE_PER_BUSINESS_DAY_ADVANCE`), provide a single `value`.\n\n**Rounding.** Computed discount and interest amounts are rounded to the nearest cent.\n",
             "type": "object",
             "properties": {
               "modality": {
                 "type": "string",
                 "enum": [
                   "FIXED_VALUE_UNTIL_SPECIFIED_DATE",
-                  "PERCENTAGE_UNTIL_SPECIFIED_DATE"
+                  "PERCENTAGE_UNTIL_SPECIFIED_DATE",
+                  "VALUE_PER_RUNNING_DAY_ADVANCE",
+                  "VALUE_PER_BUSINESS_DAY_ADVANCE",
+                  "PERCENTAGE_PER_RUNNING_DAY_ADVANCE",
+                  "PERCENTAGE_PER_BUSINESS_DAY_ADVANCE"
                 ],
                 "description": "Modality of discount to be applied"
               },
               "discountFixedDate": {
-                "description": "Absolute discounts applied to charge.",
+                "description": "Absolute discounts applied to charge. Required when `modality` is `FIXED_VALUE_UNTIL_SPECIFIED_DATE` or `PERCENTAGE_UNTIL_SPECIFIED_DATE`. Must contain at least one entry.",
                 "type": "array",
+                "minItems": 1,
                 "items": {
                   "type": "object",
                   "properties": {
                     "daysActive": {
-                      "type": "number",
-                      "description": "Days active for the discount"
+                      "type": "integer",
+                      "minimum": 1,
+                      "description": "Offset in days from charge creation. The discount is valid for payments up to and including this many days after the charge was created. On persistence, the server normalizes this offset into an absolute calendar date (`data`, format `YYYY-MM-DD`) — that is the field returned by the GET endpoint.\n"
                     },
                     "value": {
                       "type": "number",
-                      "description": "Value in cents of the discount"
+                      "description": "Discount value. Units depend on modality:\n  - `FIXED_VALUE_UNTIL_SPECIFIED_DATE`: cents.\n  - `PERCENTAGE_UNTIL_SPECIFIED_DATE`: basis points (e.g. 100 = 1.00%).\n"
+                    },
+                    "data": {
+                      "type": "string",
+                      "format": "date",
+                      "readOnly": true,
+                      "description": "Server-computed absolute date (`YYYY-MM-DD`) corresponding to `daysActive` at charge-creation time. Read-only — populated automatically and returned on GET; do not send on POST.\n"
                     }
                   }
                 }
+              },
+              "value": {
+                "type": "number",
+                "minimum": 1,
+                "description": "Discount value. Required when `modality` is one of the advance-day modalities. Must be `>= 1`.\nUnits depend on modality:\n  - `VALUE_PER_RUNNING_DAY_ADVANCE`: cents per running day.\n  - `VALUE_PER_BUSINESS_DAY_ADVANCE`: cents per business day.\n  - `PERCENTAGE_PER_RUNNING_DAY_ADVANCE`, `PERCENTAGE_PER_BUSINESS_DAY_ADVANCE`: basis points (e.g. 100 = 1.00%).\n"
               }
             }
           },
@@ -13845,6 +14210,69 @@
                 }
               }
             }
+          }
+        }
+      },
+      "AccountLimit": {
+        "type": "object",
+        "properties": {
+          "pixDayLimit": {
+            "type": "number",
+            "description": "Pix day total limit in cents"
+          },
+          "pixNightLimit": {
+            "type": "number",
+            "description": "Pix night total limit in cents"
+          },
+          "pixOutSameHolderDayLimit": {
+            "type": "number",
+            "description": "Pix outbound day limit for transfers between same-holder accounts (cents)"
+          },
+          "pixOutDifferentHolderDayLimit": {
+            "type": "number",
+            "description": "Pix outbound day limit for transfers between different-holder accounts (cents)"
+          },
+          "pixOutSameHolderNightLimit": {
+            "type": "number",
+            "description": "Pix outbound night limit for transfers between same-holder accounts (cents)"
+          },
+          "pixOutDifferentHolderNightLimit": {
+            "type": "number",
+            "description": "Pix outbound night limit for transfers between different-holder accounts (cents)"
+          },
+          "pixInSameHolderDayLimit": {
+            "type": "number",
+            "description": "Pix inbound day limit for transfers between same-holder accounts (cents)"
+          },
+          "pixInDifferentHolderDayLimit": {
+            "type": "number",
+            "description": "Pix inbound day limit for transfers between different-holder accounts (cents)"
+          },
+          "pixInSameHolderNightLimit": {
+            "type": "number",
+            "description": "Pix inbound night limit for transfers between same-holder accounts (cents)"
+          },
+          "pixInDifferentHolderNightLimit": {
+            "type": "number",
+            "description": "Pix inbound night limit for transfers between different-holder accounts (cents)"
+          },
+          "dayStartAt": {
+            "type": "string",
+            "description": "Start time of the day window (HH:mm)",
+            "example": "06:00"
+          },
+          "nightStartAt": {
+            "type": "string",
+            "description": "Start time of the night window (HH:mm)",
+            "example": "20:00"
+          },
+          "boletoEmissionLimit": {
+            "type": "number",
+            "description": "Maximum number of boletos that can be emitted per day"
+          },
+          "boletoMaximumValueLimit": {
+            "type": "number",
+            "description": "Maximum value (in cents) allowed per boleto emission"
           }
         }
       },
@@ -15768,6 +16196,10 @@
     {
       "name": "kyc",
       "description": "Endpoints for KYC onboarding"
+    },
+    {
+      "name": "account limits",
+      "description": "Endpoints to query account limits for a given bank account.\n"
     },
     {
       "name": "partner (request access)",


### PR DESCRIPTION
## Summary
- Adds `docs/account-limits/` with the getting-started guide and the endpoint reference for `GET /api/v1/limits/{accountId}` (public account-limits API).
- Updates `src/swaggers/woovi.yml` and `static/swaggers/woovi.json` with the regenerated consolidated OpenAPI spec from the woovi monorepo, so the new endpoint shows up in the API Reference.

## Companion PRs
- entria/account-limits#895
- entria/woovi#99865
- Open-Pix/openpix-developers (linked below)

## Test plan
- [ ] New section "API Account Limits" appears in the sidebar
- [ ] Getting-started page renders with Basic Auth instructions (clientId/clientSecret)
- [ ] Endpoint reference page links into the swagger API Reference
- [ ] API Reference shows the new path `GET /api/v1/limits/{accountId}` under tag `account limits`