### PR TITLE
docs(payment): add decode-emv page and fix check-pix-key

### DIFF
--- a/docs/payment/check-pix-key.md
+++ b/docs/payment/check-pix-key.md
@@ -14,28 +14,105 @@ Logo é nescessario ter acesso ao numero da conta no banco central para realizar
 Esse endpoint tem a função de validar esse vinculo com o banco central
 
 ![diagram sequencial checagem de chave pix](./__assets__/sequenceDiagrama_checagem_de_chave_pix.png)
-- O novo endpoint  de verificação de chave de pix retornará os dados sobre uma chave de pix:
-```json
-curl -X POST "https://api.woovi.com/api/v1/pix-keys/{pix-key}/check" \
+
+O endpoint de verificação de chave de pix retornará os dados sobre uma chave de pix. A chave pode ser informada no path (GET) ou no corpo da requisição (POST).
+
+- Usando GET com a chave no path:
+```bash
+curl -X GET "https://api.woovi.com/api/v1/pix-keys/{pix-key}/check" \
+  -H "Authorization: {APP_ID}"
+```
+
+- Usando POST com a chave no corpo (útil quando a chave contém caracteres que ficam ruins no path, como e-mails):
+```bash
+curl -X POST "https://api.woovi.com/api/v1/pix-keys/check" \
   -H "Authorization: {APP_ID}" \
-  -H "Content-Type: application/json"
+  -H "Content-Type: application/json" \
+  --data-raw '{
+    "pixKey": "<chave pix>"
+  }'
 ```
 
 ## Limitação de Taxa
 
 - O endpoint tem um limitador de taxa, devido às restrições do Bacen, por isso o Woovi tem um limite de taxa nesse endpoint.
-- O único problema é que quando você recebe um 404 em uma chave de pixel, após alguns 404, você receberá um 429 e precisará aguardar o reabastecimento do limitador de taxa.
+- Quando você recebe um 404 em uma chave de pix, após alguns 404, você receberá um 429 e precisará aguardar o reabastecimento do limitador de taxa.
 
 ### O que é retornado ?
 
+- O campo `type` segue o enum: `CPF`, `CNPJ`, `EMAIL`, `PHONE`, `RANDOM` ou `EVP`.
+- `pixKey` volta na **forma normalizada**, independente de como você enviou:
+  - CPF / CNPJ → só dígitos (`00000000191`, `00000000000191`)
+  - EMAIL → em lowercase
+  - PHONE → formato internacional E.164 (`+5511999998888`)
+  - RANDOM / EVP → UUID de 36 chars intacto
+- `owner.name` volta inteiro (não mascarado).
+- `owner.taxID`: para **CPF** vem parcialmente mascarado, preservando os 3 primeiros e os 2 últimos dígitos (ex: `111.***.***-80`); para **CNPJ** vem inteiro e formatado (ex: `00.000.000/0001-91`).
+- `owner.branch` e `owner.account` voltam totalmente mascarados (`****` / `********`).
+- `owner.psp` é o **código ISPB** (8 dígitos) do PSP da chave, não o nome do banco — se precisar exibir o nome, mantenha um mapeamento ISPB → instituição do seu lado.
+- A cada chamada o DICT é consultado de novo e um novo `pixKeyEndToEndId` é gerado. Esse identificador é o que você precisa guardar e enviar no endpoint de [Criar Pagamento](./payment-how-to-use-api-to-create.mdx).
+
 ```json
 {
-    "pixKeyEndToEndId": "...",
-    "pixKey": "...",
-    "type": "...",
-    "owne": {
-        "name": "...",
-        "taxID": "...",
-                }
+  "pixKeyEndToEndId": "E12345678202601011200abcdefghijk",
+  "pixKey": "00000000191",
+  "type": "CPF",
+  "owner": {
+    "name": "Fulano de Tal",
+    "taxID": "000.***.***-91",
+    "psp": "12345678",
+    "branch": "****",
+    "account": "********************"
+  }
 }
 ```
+
+## Erros possíveis
+
+- `400` — chave em formato inválido (não passou em `CPF` / `CNPJ` / `EMAIL` / `PHONE` / UUID de 36 chars)
+- `404 PIX_KEY_INFO_NOT_FOUND` — chave válida mas não cadastrada no DICT
+- `400` para chave de risco — `Pix key related to an account suspected of fraud`
+- `400` para DICT indisponível — `Error verifying pix key`
+- `429` — rate limit do Bacen estourado (veja a seção "Limitação de Taxa" acima)
+- `403 PIX_KEY_CHECK_NOT_ALLOWED` — sua conta não tem a feature liberada
+
+Na rota `GET` os erros voltam com `error` + `errorCode`. Na rota `POST` apenas `error` é retornado.
+
+## Cobrança
+
+Cada consulta bem-sucedida pode gerar uma tarifa, que vem das configurações de fee da sua conta. A cobrança é **idempotente por dia, conta e chave**: consultar a mesma chave Pix mais de uma vez na mesma conta no mesmo dia gera só uma cobrança. Erros (chave não encontrada, rate limit, etc.) não geram cobrança.
+
+## Prompt para IA
+
+Copie o trecho abaixo numa IA de coding (Claude / Cursor / Gemini / ChatGPT) pra implementar a integração no seu app:
+
+> Implemente uma função `checkPixKey(pixKey)` que consulta uma chave Pix no DICT do Banco Central via Woovi e devolve nome do titular, banco e identificador necessário pra pagamento.
+>
+> **Endpoint**: `POST https://api.woovi.com/api/v1/pix-keys/check`
+> **Header**: `Authorization: <APP_ID>` e `Content-Type: application/json`
+> **Body**: `{ "pixKey": "<chave>" }` (aceita CPF, CNPJ, email, telefone ou EVP/UUID; não aceita BRcode/copia e cola — use o endpoint de decode/emv pra isso)
+>
+> **Resposta de sucesso (200)**:
+> ```json
+> {
+>   "pixKeyEndToEndId": "E12345678202601011200abcdefghijk",
+>   "pixKey": "<chave normalizada>",
+>   "type": "CPF" | "CNPJ" | "EMAIL" | "PHONE" | "RANDOM" | "EVP",
+>   "owner": {
+>     "name": "<nome do titular>",
+>     "taxID": "<CPF parcialmente mascarado ou CNPJ inteiro>",
+>     "psp": "<ISPB de 8 dígitos do banco da chave>",
+>     "branch": "****",
+>     "account": "********************"
+>   }
+> }
+> ```
+>
+> **Erros a tratar**: 404 `PIX_KEY_INFO_NOT_FOUND` (chave não encontrada), 400 (chave inválida ou chave de risco), 429 (rate limit do Bacen), 403 `PIX_KEY_CHECK_NOT_ALLOWED` (feature não liberada).
+>
+> **Detalhes importantes**:
+> - `psp` é só o código ISPB (8 dígitos) — pra mostrar nome do banco mantenha um mapeamento ISPB → nome do seu lado.
+> - `pixKey` sempre volta normalizado: telefone em E.164 (`+55...`), email em lowercase, CPF/CNPJ só dígitos.
+> - `owner.taxID` de CPF vem mascarado (ex `111.***.***-80`); de CNPJ vem inteiro.
+> - Cada consulta bem-sucedida pode ter custo, mas é idempotente por dia/conta/chave.
+> - Guarde o `pixKeyEndToEndId` retornado se for usar pra criar um pagamento depois.

--- a/docs/payment/decode-emv.md
+++ b/docs/payment/decode-emv.md
@@ -9,9 +9,10 @@ Este documento irá ajudá-lo a decodificar uma string de QR Code Pix ou Copia e
 
 O Copia e Cola é a mesma string que o QR Code carrega visualmente — basta passar essa string no body que o endpoint devolve os dados já parseados.
 
-O endpoint cobre os dois tipos de QR:
-- **Estático**: chave Pix, valor e nome do recebedor já estão no payload e voltam direto na resposta.
-- **Dinâmico (COB ou REC)**: o payload carrega apenas uma URL `location` apontando pro PSP emissor. O próprio endpoint resolve essa URL, baixa a cobrança assinada (JWS) e devolve junto na resposta — você não precisa fazer essa parte por conta.
+O endpoint cobre os três cenários típicos:
+- **Estático**: chave Pix, valor e nome do recebedor já estão dentro do próprio payload e voltam direto na resposta, sem nenhuma chamada externa.
+- **Dinâmico de cobrança (COB / COBV)**: o payload carrega uma URL `location` apontando pro PSP emissor da cobrança. O endpoint resolve essa URL, baixa o payload retornado pelo PSP e devolve em `cobLocation.payload`. O conteúdo vem em JWS assinado pelo PSP, mas a Woovi **não valida** a assinatura ICP-Brasil nem o domínio — se precisar dessa garantia, valide pelo seu lado a partir do `url`/`payload` retornado.
+- **Pix Automático (REC)**: similar ao dinâmico, mas a `location` vem em outra tag do EMV (`unreservedTemplates`) e aponta para a estrutura de recorrência (idRec, periodicidade, contrato). O endpoint resolve e devolve em `recLocation.payload`.
 
 - Faça a requisição passando a string do QR / Copia e Cola no campo `emv`:
 ```bash

--- a/docs/payment/decode-emv.md
+++ b/docs/payment/decode-emv.md
@@ -1,0 +1,230 @@
+---
+id: decode-emv
+title: Decodificar QR Code Pix / Copia e Cola
+tags:
+  - api
+---
+
+Este documento irá ajudá-lo a decodificar uma string de QR Code Pix ou Copia e Cola (formato EMV / BR Code do BCB).
+
+O Copia e Cola é a mesma string que o QR Code carrega visualmente — basta passar essa string no body que o endpoint devolve os dados já parseados.
+
+O endpoint cobre os dois tipos de QR:
+- **Estático**: chave Pix, valor e nome do recebedor já estão no payload e voltam direto na resposta.
+- **Dinâmico (COB ou REC)**: o payload carrega apenas uma URL `location` apontando pro PSP emissor. O próprio endpoint resolve essa URL, baixa a cobrança assinada (JWS) e devolve junto na resposta — você não precisa fazer essa parte por conta.
+
+- Faça a requisição passando a string do QR / Copia e Cola no campo `emv`:
+```bash
+curl -X POST "https://api.woovi.com/api/v1/decode/emv" \
+  -H "Authorization: {APP_ID}" \
+  -H "Content-Type: application/json" \
+  --data-raw '{
+    "emv": "<string do QR Code ou Copia e Cola>"
+  }'
+```
+
+### O que é retornado ?
+
+A resposta sempre traz o objeto `emv` com o payload parseado e, quando aplicável, `cobLocation` ou `recLocation` com os dados resolvidos no PSP emissor.
+
+Exemplo de resposta para um QR dinâmico de cobrança imediata (COB):
+
+```json
+{
+  "emv": {
+    "payloadFormatIndicator": "01",
+    "pointOfInitiationMethod": "12",
+    "merchantAccountInformationPix": {
+      "gui": "br.gov.bcb.pix",
+      "url": "qr-h.woovi.digital/qr/v2/cob/fb274322-221c-43d4-b58b-fab36d87c75c"
+    },
+    "merchantCategoryCode": "0000",
+    "transactionCurrency": "986",
+    "transactionAmount": "10.00",
+    "countryCode": "BR",
+    "merchantName": "Fulano",
+    "merchantCity": "Sao_Paulo",
+    "additionalDataFieldTemplate": {
+      "referenceLabel": "fb274322-221c-43d4-b58b-f"
+    },
+    "crc": "0C98"
+  },
+  "cobLocation": {
+    "isValid": true,
+    "locationErrors": [],
+    "payload": {
+      "calendar": {
+        "presentation": "2025-02-25T13:27:54.168Z",
+        "expiration": 86400,
+        "creation": "2025-02-12T16:59:22.939Z"
+      },
+      "key": "4004901d-bd85-4769-8e52-cb4c42c506dc",
+      "debtor": {
+        "cpf": "62550186362",
+        "name": "Fulano de Tal"
+      },
+      "additionalInfo": [
+        { "name": "Entrega", "value": "Residencial" }
+      ],
+      "revision": 0,
+      "status": "ATIVA",
+      "txid": "d71a2ffd7a7b468eba993cef83428583",
+      "value": { "original": "120.58" }
+    },
+    "url": "qr-h.woovi.digital/qr/v2/cob/fb274322-221c-43d4-b58b-fab36d87c75c"
+  },
+  "recLocation": null
+}
+```
+
+Quando o QR é uma cobrança com vencimento (COBV), o `cobLocation.payload` traz campos adicionais — `calendar.dueDate`, `validityAfterDueDate`, subcampos de juros/multa/desconto em `value` e dados completos do recebedor. Esses campos vêm direto do PSP emissor da cobrança, então a presença depende do que o PSP devolve:
+
+```json
+{
+  "emv": {
+    "payloadFormatIndicator": "01",
+    "pointOfInitiationMethod": "12",
+    "merchantAccountInformationPix": {
+      "gui": "br.gov.bcb.pix",
+      "url": "qrcode.exemplo.com.br/v1/cobv/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+    },
+    "merchantCategoryCode": "0000",
+    "transactionCurrency": "986",
+    "countryCode": "BR",
+    "merchantName": "Fulano Comercio LTDA",
+    "merchantCity": "FLORIANOPOLIS",
+    "additionalDataFieldTemplate": {
+      "referenceLabel": "***"
+    },
+    "crc": "F684"
+  },
+  "cobLocation": {
+    "isValid": true,
+    "locationErrors": [],
+    "payload": {
+      "calendar": {
+        "dueDate": "2026-05-22",
+        "validityAfterDueDate": 30,
+        "creation": "2026-05-22T16:07:05.051Z",
+        "presentation": "2026-05-22T16:07:05.051Z"
+      },
+      "value": {
+        "original": "100.00",
+        "final": "100.00",
+        "interest": "0.00",
+        "fine": "0.00",
+        "discount": "0.00",
+        "rebate": "0.00"
+      },
+      "receiver": {
+        "street": "Rua Exemplo 123",
+        "city": "Florianopolis",
+        "state": "SC",
+        "zipcode": "88000000",
+        "cnpj": "00000000000191",
+        "name": "Fulano Comercio LTDA"
+      },
+      "debtor": {
+        "cpf": "00000000191",
+        "name": "Maria Compradora"
+      },
+      "revision": 0,
+      "key": "11111111-2222-3333-4444-555555555555",
+      "txid": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+      "status": "ATIVA"
+    },
+    "url": "qrcode.exemplo.com.br/v1/cobv/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+  },
+  "recLocation": null
+}
+```
+
+Exemplo de resposta para um QR de Pix Automático (REC):
+
+```json
+{
+  "emv": {
+    "payloadFormatIndicator": "01",
+    "merchantAccountInformationPix": {
+      "gui": "br.gov.bcb.pix",
+      "pixKey": "f4c6089a-bfde-4c00-a2d9-9eaa584b0219",
+      "additionalInformation": "CobrancaEstatica"
+    },
+    "merchantCategoryCode": "0000",
+    "transactionCurrency": "986",
+    "transactionAmount": "546.28",
+    "countryCode": "BR",
+    "merchantName": "Pix",
+    "merchantCity": "BRASILIA",
+    "additionalDataFieldTemplate": {
+      "referenceLabel": "84767c56c2ab4e65b6670de2a"
+    },
+    "unreservedTemplates": {
+      "gui": "br.gov.bcb.pix",
+      "url": "qr-h.sandbox.pix.bcb.gov.br/rest/api/rec/4b62d4a088fe4f51bcb4c64cf0788691"
+    },
+    "crc": "4486"
+  },
+  "cobLocation": null,
+  "recLocation": {
+    "isValid": true,
+    "locationErrors": [],
+    "payload": {
+      "updates": [
+        { "date": "2025-10-24T18:42:58Z", "status": "CRIADA" }
+      ],
+      "calendar": {
+        "startDate": "2025-10-24",
+        "periodicity": "SEMANAL"
+      },
+      "idRec": "RN5481141720251024BnwNHejs9h9",
+      "retryPolicy": "NAO_PERMITE",
+      "receiver": {
+        "cnpj": "44720743000101",
+        "participantIspb": "54811417",
+        "name": "Woovi Demo"
+      },
+      "value": { "valueRec": "0.01" },
+      "link": {
+        "contract": "Woovi Demo - Pix Automático",
+        "debtor": {
+          "cpf": "15775023706",
+          "name": "Pedro Cliente"
+        }
+      }
+    },
+    "url": "qr-h.sandbox.pix.bcb.gov.br/rest/api/rec/4b62d4a088fe4f51bcb4c64cf0788691"
+  }
+}
+```
+
+Para QR estático sem location, `cobLocation` e `recLocation` voltam como `null` e a chave / valor / nome do recebedor já estão dentro de `emv` (campos `merchantAccountInformationPix.pixKey`, `transactionAmount`, `merchantName`).
+
+### Quando combinar com a Verificação de Chave Pix
+
+Se depois do decode você for efetivamente disparar um pagamento via API, use a [Verificação de Chave Pix](./check-pix-key.md) com a chave extraída — ela devolve o `pixKeyEndToEndId` exigido pelo endpoint de [Criar Pagamento](./payment-how-to-use-api-to-create.mdx).
+
+## Prompt para IA
+
+Copie o trecho abaixo numa IA de coding (Claude / Cursor / Gemini / ChatGPT) pra implementar a integração no seu app:
+
+> Implemente uma função `decodePixCode(emv)` que aceita a string de um QR Code Pix ou copia e cola (formato BR Code) e devolve os dados do destinatário já parseados (chave Pix, valor, nome, banco), pronta pra preview antes de o usuário confirmar o pagamento.
+>
+> **Endpoint**: `POST https://api.woovi.com/api/v1/decode/emv`
+> **Header**: `Authorization: <APP_ID>` e `Content-Type: application/json`
+> **Body**: `{ "emv": "<string do QR Code ou copia e cola>" }`
+>
+> **A resposta sempre traz `emv` com o payload parseado**. Dependendo do tipo de QR, um dos dois objetos abaixo vem populado (o outro vem `null`):
+>
+> - **QR estático**: `cobLocation` e `recLocation` ambos `null`. A chave, valor e nome do recebedor já estão dentro de `emv.merchantAccountInformationPix.pixKey`, `emv.transactionAmount` e `emv.merchantName`.
+> - **QR dinâmico de cobrança imediata (COB) ou com vencimento (COBV)**: `cobLocation.payload` traz os dados completos já resolvidos no PSP emissor — `calendar` (creation/presentation/expiration ou dueDate), `value.original` (e `value.final/interest/fine/discount/rebate` para COBV), `key` (chave do recebedor), `debtor`, `receiver`, `txid`, `status`.
+> - **QR de Pix Automático (REC)**: `recLocation.payload` traz `idRec`, `calendar.periodicity` (`SEMANAL` / `MENSAL` / etc), `receiver`, `value.valueRec`, `link.contract`, `link.debtor`.
+>
+> Em todos os casos com location, `isValid` é `true` quando o PSP emissor respondeu e `false` quando não — trate como erro e mostre fallback.
+>
+> **UX recomendada**:
+> - Para o usuário, mostre o valor e o nome do recebedor logo que o decode retornar, mesmo antes da confirmação final.
+> - Se o BRcode for dinâmico, prefira os campos de `cobLocation.payload` ou `recLocation.payload` (vêm direto do PSP emissor, são autoritativos) sobre os campos dentro de `emv` (são só os do payload local).
+> - Se for disparar um pagamento via API em seguida, chame o endpoint de Pix Check com a chave extraída pra obter o `pixKeyEndToEndId` (exigido pra criar pagamento).
+>
+> Trate erros 400 (EMV inválido) e 500 mostrando mensagem amigável e oferecendo entrada manual da chave.


### PR DESCRIPTION
## Summary

- New page `docs/payment/decode-emv.md` for `POST /api/v1/decode/emv` (parses EMV / Pix Copia e Cola and, when present, resolves COB / COBV / REC locations at the issuing PSP in a single call). Endpoint was already live but undocumented.
- Fix `docs/payment/check-pix-key.md` — correct HTTP method/path, fix `"owne"` → `"owner"` typo, expand response schema and behavior notes from the actual code.

## What changed in `check-pix-key.md`

- Document the two real routes: `GET /api/v1/pix-keys/{pix-key}/check` and `POST /api/v1/pix-keys/check` (the previous example mixed POST with a path param, which doesn't exist).
- Full response schema: `pixKeyEndToEndId`, `pixKey`, `type` (`CPF`/`CNPJ`/`EMAIL`/`PHONE`/`RANDOM`/`EVP`), `owner.{name,taxID,psp,branch,account}`.
- Masking behavior (validated against live response):
  - `pixKey` and `owner.name` returned in full.
  - `owner.taxID`: CPF partially masked (`111.***.***-80`), CNPJ returned in full (`obscureTaxID` in `packages/utils/src/obscureTaxID.ts`).
  - `owner.branch` / `owner.account` fully masked (`****` / `********`).
  - `owner.psp` is the **ISPB code** (8 digits), not the bank name.
- Input normalization of `pixKey` in the response (from `formatPixKey`): phone → E.164, email → lowercase, CPF/CNPJ → digits only.
- New "Erros possíveis" section listing real codes (`PIX_KEY_INFO_NOT_FOUND`, `PIX_KEY_CHECK_NOT_ALLOWED`, `429`, fraud-suspected key, DICT unavailable) and noting the GET-returns-`errorCode`/POST-doesn't difference.
- New "Cobrança" section explaining the daily idempotent billing (same key + same account + same UTC day → one charge).

## What's in `decode-emv.md`

- Method, path, auth, request body (`{ "emv": "<BRcode>" }`).
- Behavior summary by QR type:
  - **Static**: pixKey, amount and merchant name come directly inside `emv`.
  - **Dynamic COB / COBV**: location is resolved at the issuing PSP and the cob payload (calendar, value, debtor, receiver, txid, status) returns in the same response.
  - **REC (Pix Automático)**: location resolved, with periodicity, idRec, receiver, value, link contract.
- Response examples for: dynamic COB (immediate), COBV (with `dueDate`, fine/interest/discount/rebate subfields, full receiver address), and REC. All examples use fully fictional data.

## Validation

Tested against `https://api.woovi.com/api/v1/decode/emv` and `https://api.woovi.com/api/v1/pix-keys/{key}/check` (and the POST variant). Confirmed real responses match the documented schema for: CPF, EVP/RANDOM (key belonging to a company → CNPJ comes in full), COB dynamic (qr.woovi.com), COBV (external PSP), REC (BCB sandbox). No real PII left in the examples.

## Test plan
- [ ] Open the rendered pages on the doc preview and confirm formatting / sidebar position.
- [ ] Confirm with @sibeliusbr or the API team that the COB `value.changeMode` field is intentionally absent from the OpenAPI YAML (we saw it in real responses but it's not in `scripts/decodeEMVGet.api.yml`).
- [ ] Consider adding `scripts/decodeEMVGet.api.yml` to the published OpenAPI merge so the endpoint also shows up under `/api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)