### PR TITLE
docs(payment): link decode-emv and check-pix-key to interactive API Reference

### DIFF
--- a/docs/payment/check-pix-key.md
+++ b/docs/payment/check-pix-key.md
@@ -1,7 +1,9 @@
 ---
 id: check-pix-key
+sidebar_position: 3
 title: Verificação de Chave Pix
 tags:
+  - payment
   - api
 ---
 

--- a/docs/payment/check-pix-key.md
+++ b/docs/payment/check-pix-key.md
@@ -23,6 +23,8 @@ curl -X GET "https://api.woovi.com/api/v1/pix-keys/{pix-key}/check" \
   -H "Authorization: {APP_ID}"
 ```
 
+Você pode acessar [aqui](https://developers.woovi.com/api#tag/pixKey/paths/~1api~1v1~1pix-keys~1%7BpixKey%7D~1check/get) a documentação referente a esse _endpoint_.
+
 - Usando POST com a chave no corpo (útil quando a chave contém caracteres que ficam ruins no path, como e-mails):
 ```bash
 curl -X POST "https://api.woovi.com/api/v1/pix-keys/check" \
@@ -32,6 +34,8 @@ curl -X POST "https://api.woovi.com/api/v1/pix-keys/check" \
     "pixKey": "<chave pix>"
   }'
 ```
+
+Você pode acessar [aqui](https://developers.woovi.com/api#tag/pixKey/paths/~1api~1v1~1pix-keys~1check/post) a documentação referente a esse _endpoint_.
 
 ## Limitação de Taxa
 

--- a/docs/payment/decode-emv.md
+++ b/docs/payment/decode-emv.md
@@ -1,7 +1,9 @@
 ---
 id: decode-emv
+sidebar_position: 2
 title: Decodificar QR Code Pix / Copia e Cola
 tags:
+  - payment
   - api
 ---
 

--- a/docs/payment/decode-emv.md
+++ b/docs/payment/decode-emv.md
@@ -24,6 +24,8 @@ curl -X POST "https://api.woovi.com/api/v1/decode/emv" \
   }'
 ```
 
+Você pode acessar [aqui](https://developers.woovi.com/api#tag/decode/paths/~1api~1v1~1decode~1emv/post) a documentação referente a esse _endpoint_.
+
 ### O que é retornado ?
 
 A resposta sempre traz o objeto `emv` com o payload parseado e, quando aplicável, `cobLocation` ou `recLocation` com os dados resolvidos no PSP emissor.


### PR DESCRIPTION
## Summary

Follow-up to #678. Adds the conventional "Você pode acessar [aqui](...) a documentação referente a esse _endpoint_." line after each curl example, pointing to the corresponding endpoint in the Scalar-rendered `/api` Reference.

Matches the same pattern already used across `docs/payment/`, `docs/refund/`, `docs/subscription-recurrence/`, `docs/qrcode-static/`, `docs/charge/`, `docs/cashback-fidelity/`, etc.

## Changes

- `docs/payment/decode-emv.md` — link to `#tag/decode/paths/~1api~1v1~1decode~1emv/post`
- `docs/payment/check-pix-key.md` — links to both routes: GET `#tag/pixKey/paths/~1api~1v1~1pix-keys~1%7BpixKey%7D~1check/get` and POST `#tag/pixKey/paths/~1api~1v1~1pix-keys~1check/post`

URL anchor convention (`~1` = `/`, `%7B...%7D` = `{...}`) and tag names confirmed against the live `/swaggers/woovi.json` spec.

## Test plan
- [ ] Open each link from the rendered pages and confirm they land on the right endpoint in the Scalar viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)