### PR TITLE
docs(stablecoin): add stablecoin API documentation section

### DIFF
--- a/docs/stablecoin/_category_.json
+++ b/docs/stablecoin/_category_.json
@@ -1,0 +1,13 @@
+{
+  "label": "Stablecoin",
+  "collapsible": true,
+  "collapsed": true,
+  "className": "red",
+  "link": {
+    "type": "generated-index",
+    "title": "Stablecoin - visão geral"
+  },
+  "customProps": {
+    "description": "Stablecoin (USDT/USDC) documentação"
+  }
+}

--- a/docs/stablecoin/stablecoin-endpoints.md
+++ b/docs/stablecoin/stablecoin-endpoints.md
@@ -1,0 +1,227 @@
+---
+id: stablecoin-endpoints
+sidebar_position: 2
+title: Endpoints
+tags:
+  - stablecoin
+  - api
+---
+
+## Rotas da API de Stablecoin
+
+Você pode ver os detalhes completos na [referência da API](https://developers.woovi.com/api#tag/stablecoin).
+
+Todas as rotas ficam sob `/api/v1/stablecoin/` e exigem autenticação com o seu App (header `Authorization`). Cada rota exige um escopo (`scope`) específico no seu App:
+
+| Escopo | Rotas |
+| --- | --- |
+| `STABLECOIN_DEPOSIT_CREATE` | `quote`, `deposit`, `deposit/approve` |
+| `STABLECOIN_DEPOSIT_LIST` | `deposit/find`, `deposit` (listar) |
+| `STABLECOIN_SUBACCOUNT_LIST` | `subaccount`, `subaccount/{subAccountId}` |
+
+> A URL base de produção é `https://api.woovi.com`. Caso o App não tenha o escopo necessário, a resposta é `401` com `Application is missing required scope: ...`.
+
+### Cotação (Quote)
+
+GET `/api/v1/stablecoin/quote`
+
+Retorna uma cotação BRL → stablecoin **sem criar um depósito**. Use para exibir ao cliente exatamente quanto de stablecoin ele receberia antes de confirmar. A cotação é armazenada em cache por 60 segundos.
+
+Query params:
+
+- `value` (obrigatório) — valor a cotar, **em centavos** de BRL (ex.: `10000` = R$ 100,00)
+- `currency` (opcional) — `USDT` | `USDC` (padrão: `USDT`)
+
+```bash
+curl --request GET \
+  --url 'https://api.woovi.com/api/v1/stablecoin/quote?value=10000&currency=USDT' \
+  --header 'Authorization: <SEU_APP_ID>'
+```
+
+Resposta:
+
+```json
+{
+  "status": "ok",
+  "quote": {
+    "basePrice": 5.25,
+    "inputAmount": 100,
+    "inputCurrency": "BRL",
+    "outputAmount": 19.04,
+    "outputCurrency": "USDT",
+    "appliedFees": [
+      { "type": "In Fee", "amount": 1.5, "currency": "BRL" }
+    ],
+    "pairName": "BRL/USDT"
+  }
+}
+```
+
+> `inputAmount` e `outputAmount` no retorno da cotação são em unidade de moeda (não em centavos). Caso o provedor não consiga cotar, a resposta é `502` com `{ "status": "error", "error": "Unable to fetch quote" }`.
+
+### Criar um depósito
+
+POST `/api/v1/stablecoin/deposit`
+
+Cria um depósito de stablecoin a partir do saldo em BRL da conta. Retorna `depositId`, `correlationId` e uma cotação com as taxas aplicadas. A aprovação (`/deposit/approve`) é que debita o saldo da conta.
+
+Body:
+
+| campo | tipo | obrigatório | descrição |
+| --- | --- | --- | --- |
+| `value` | number | sim | valor em **centavos** de BRL (ex.: `10000` = R$ 100,00) |
+| `currency` | string | sim | `USDT` \| `USDC` |
+| `network` | string | não | `POLYGON` (padrão) \| `ETHEREUM` \| `BASE` \| `CELO` \| `TRON` |
+| `subAccountId` | string | não | subconta a usar; resolvida pela empresa quando omitida |
+| `correlationId` | string | não | identificador único para idempotência |
+| `destinationWalletAddress` | string | não | carteira de destino explícita para a stablecoin |
+
+```bash
+curl --request POST \
+  --url https://api.woovi.com/api/v1/stablecoin/deposit \
+  --header 'Authorization: <SEU_APP_ID>' \
+  --header 'content-type: application/json' \
+  --data '{
+    "value": 10000,
+    "currency": "USDT",
+    "network": "POLYGON",
+    "correlationId": "my-unique-id"
+  }'
+```
+
+Resposta:
+
+```json
+{
+  "status": "PENDING",
+  "depositId": "6650abc1234def567890aaaa",
+  "correlationId": "my-unique-id",
+  "expiration": "2026-06-05T12:00:00.000Z",
+  "quote": {
+    "inputAmount": 10000,
+    "inputCurrency": "BRL",
+    "outputAmount": 18.45,
+    "outputCurrency": "USDT",
+    "rate": 5.42,
+    "fee": 50
+  }
+}
+```
+
+Erros comuns (`400`):
+
+```json
+{ "error": "value must be a positive number (in cents)" }
+{ "error": "currency must be one of: USDT, USDC" }
+{ "error": "USDT is not available on BASE. Supported networks: POLYGON, ETHEREUM, CELO, TRON" }
+{ "error": "Nenhuma subconta de stablecoin ativa. É necessário um KYB, entre em contato com o suporte." }
+```
+
+### Aprovar (liquidar) um depósito
+
+POST `/api/v1/stablecoin/deposit/approve`
+
+Aprova um depósito já criado, identificado pelo `correlationId`, disparando a liquidação on-chain (pagamento do QR Code stablecoin). O depósito passa para `PROCESSING` enquanto a liquidação está em andamento.
+
+Body:
+
+- `correlationId` (obrigatório) — o `correlationId` informado na criação do depósito
+
+```bash
+curl --request POST \
+  --url https://api.woovi.com/api/v1/stablecoin/deposit/approve \
+  --header 'Authorization: <SEU_APP_ID>' \
+  --header 'content-type: application/json' \
+  --data '{ "correlationId": "my-unique-id" }'
+```
+
+Resposta:
+
+```json
+{
+  "status": "PROCESSING",
+  "correlationId": "my-unique-id",
+  "depositId": "6650abc1234def567890aaaa"
+}
+```
+
+A aprovação é rejeitada com `400` quando o depósito não pode ser aprovado, por exemplo: já está `COMPLETED`, já está `PROCESSING`, não há conta de origem para pagar, ou a cotação/pagamento do provedor falhou.
+
+```json
+{ "error": "Stablecoin deposit already completed", "correlationId": "my-unique-id", "depositId": "6650abc1234def567890aaaa" }
+```
+
+### Buscar um depósito
+
+GET `/api/v1/stablecoin/deposit/find?correlationId={correlationId}`
+
+Busca um único depósito pelo `correlationId`.
+
+```json
+{
+  "status": "ok",
+  "deposit": {
+    "id": "6650abc1234def567890aaaa",
+    "correlationId": "my-unique-id",
+    "status": "COMPLETED",
+    "inputAmount": 10000,
+    "inputCurrency": "BRL",
+    "outputAmount": 18.45,
+    "outputCurrency": "USDT",
+    "fee": 50,
+    "createdAt": "2026-06-05T12:00:00.000Z"
+  }
+}
+```
+
+### Listar depósitos
+
+GET `/api/v1/stablecoin/deposit?limit={limit}&skip={skip}`
+
+Lista os depósitos da empresa autenticada (paginado).
+
+```json
+{
+  "status": "ok",
+  "deposits": [ { "id": "6650abc1234def567890aaaa", "status": "COMPLETED", "inputAmount": 10000, "inputCurrency": "BRL", "outputAmount": 18.45, "outputCurrency": "USDT", "fee": 50, "createdAt": "2026-06-05T12:00:00.000Z" } ],
+  "count": 42,
+  "limit": 20,
+  "skip": 0
+}
+```
+
+### Listar subcontas
+
+GET `/api/v1/stablecoin/subaccount`
+
+Lista as subcontas de stablecoin (registros de KYB) da empresa autenticada.
+
+```json
+{
+  "status": "ok",
+  "subAccounts": [
+    {
+      "id": "6650abc1234def567890aaaa",
+      "subAccountId": "sub_01HZ...",
+      "account": "6650def1234abc567890bbbb",
+      "createdAt": "2026-06-05T12:00:00.000Z"
+    }
+  ]
+}
+```
+
+### Buscar uma subconta
+
+GET `/api/v1/stablecoin/subaccount/{subAccountId}`
+
+```json
+{
+  "status": "ok",
+  "subAccount": {
+    "id": "6650abc1234def567890aaaa",
+    "subAccountId": "sub_01HZ...",
+    "account": "6650def1234abc567890bbbb",
+    "createdAt": "2026-06-05T12:00:00.000Z"
+  }
+}
+```

--- a/docs/stablecoin/stablecoin-fees.md
+++ b/docs/stablecoin/stablecoin-fees.md
@@ -1,0 +1,59 @@
+---
+id: stablecoin-fees
+sidebar_position: 5
+title: Taxas
+tags:
+  - stablecoin
+  - api
+---
+
+## Taxas do Stablecoin
+
+O valor total de taxas de um depósito é composto por:
+
+1. **Taxa Woovi** — por padrão **2%** sobre o valor do depósito.
+2. **Taxas do provedor (on-chain / conversão)** — aplicadas pelo provedor de liquidação e detalhadas na cotação, por exemplo `In Fee` (taxa de entrada) e `Conversion Fee` (taxa de conversão).
+
+A taxa Woovi padrão de 2% pode ser personalizada por ativo no contrato da sua subconta, definida como um percentual, com limites mínimo e máximo opcionais.
+
+## Onde ver as taxas
+
+### Na cotação
+
+O endpoint [`GET /api/v1/stablecoin/quote`](./stablecoin-endpoints.md#cotação-quote) retorna a quebra das taxas do provedor em `appliedFees`:
+
+```json
+{
+  "quote": {
+    "basePrice": 5.25,
+    "inputAmount": 100,
+    "inputCurrency": "BRL",
+    "outputAmount": 19.04,
+    "outputCurrency": "USDT",
+    "appliedFees": [
+      { "type": "In Fee", "amount": 1.5, "currency": "BRL" },
+      { "type": "Conversion Fee", "amount": 0.5, "currency": "BRL" }
+    ],
+    "pairName": "BRL/USDT"
+  }
+}
+```
+
+### No depósito
+
+A resposta de [`POST /api/v1/stablecoin/deposit`](./stablecoin-endpoints.md#criar-um-depósito) traz, dentro de `quote`, o campo `fee` com o **total** das taxas (taxa Woovi + taxas do provedor), em centavos de BRL:
+
+```json
+{
+  "quote": {
+    "inputAmount": 10000,
+    "inputCurrency": "BRL",
+    "outputAmount": 18.45,
+    "outputCurrency": "USDT",
+    "rate": 5.42,
+    "fee": 50
+  }
+}
+```
+
+> O `outputAmount` já é líquido das taxas — ou seja, é exatamente quanto de stablecoin o cliente recebe.

--- a/docs/stablecoin/stablecoin-flow.md
+++ b/docs/stablecoin/stablecoin-flow.md
@@ -1,0 +1,129 @@
+---
+id: stablecoin-flow
+sidebar_position: 3
+title: Fluxo passo a passo
+tags:
+  - stablecoin
+  - api
+---
+
+O fluxo de stablecoin segue a ideia de **criar um depósito e aprová-lo**: a aprovação debita o saldo em BRL da conta da sua empresa e entrega a stablecoin (USDT) na carteira de destino.
+
+## Fluxograma
+
+```mermaid
+sequenceDiagram
+    participant E as Sua Empresa
+    participant W as Woovi
+    participant B as Blockchain
+    E->>W: GET /quote (opcional)
+    W-->>E: Cotação (outputAmount, taxas)
+    E->>W: POST /deposit
+    W-->>E: depositId + correlationId + status PENDING
+    E->>W: POST /deposit/approve
+    Note over W: Debita o saldo BRL da conta da empresa
+    W-->>E: status PROCESSING
+    W->>B: Liquidação on-chain (entrega da stablecoin)
+    B-->>W: txHash
+    alt Sucesso
+        W->>E: webhook STABLECOIN_DEPOSIT_COMPLETED (txHash)
+    else Falha
+        W->>E: webhook STABLECOIN_DEPOSIT_FAILED (reason, errorCode)
+    end
+```
+
+### Contas, subcontas e limites
+
+Cada empresa (**CONTA PJ**) tem uma **subconta de stablecoin** para comprar a stable, e **cada conta tem seus próprios limites**. Precisa de outra conta? Você pode criar uma nova CONTA PJ usando o nosso [**BaaS**](/docs/category/baas).
+
+```mermaid
+flowchart LR
+  subgraph PJ1["CONTA PJ · limites próprios"]
+    SA1["SubAccount<br/>comprar stable"]
+  end
+  BAAS(["BaaS: criar mais uma conta"])
+  subgraph PJ2["CONTA PJ · limites próprios"]
+    SA2["SubAccount<br/>comprar stable"]
+  end
+  PJ1 ==> BAAS ==> PJ2
+  click BAAS "/docs/category/baas" "Documentação de BaaS"
+```
+
+### Recebendo via cobrança (exemplo)
+
+Usando o fluxo normal de cobrança (charge) para receber o dinheiro do cliente e, em seguida, criar e aprovar o depósito de stablecoin:
+
+```mermaid
+flowchart LR
+  A["Charge"] --> B["Pagamento recebido"] --> C["Depósito USDT criado"] --> D["Depósito USDT aprovado"] --> E["tx hash"]
+```
+
+## Pré-requisitos
+
+1. Sua empresa precisa de uma subconta de stablecoin com status `CONFIRMED` (KYB aprovado). Veja [O que é o Stablecoin?](./stablecoin-what-is-it.md).
+2. A conta da empresa precisa de **saldo em BRL** suficiente — a aprovação debita esse saldo para comprar a stablecoin.
+3. Configure os [webhooks](./stablecoin-webhooks.md) para ser notificado quando o depósito concluir ou falhar. Os indispensáveis são:
+   - `STABLECOIN_DEPOSIT_COMPLETED`
+   - `STABLECOIN_DEPOSIT_FAILED`
+
+## Passo a passo
+
+### 1. (Opcional) Cotar o valor
+
+Antes de criar o depósito, você pode consultar quanto de stablecoin o cliente receberá:
+
+GET `/api/v1/stablecoin/quote?value=10000&currency=USDT`
+
+A resposta traz `outputAmount`, `basePrice` e as taxas aplicadas (`appliedFees`). Útil para exibir a cotação na sua interface. A cotação fica em cache por 60 segundos.
+
+### 2. Criar o depósito
+
+POST `/api/v1/stablecoin/deposit`
+
+```json
+{
+  "value": 10000,
+  "currency": "USDT",
+  "network": "POLYGON",
+  "correlationId": "my-unique-id"
+}
+```
+
+O depósito é criado com status `PENDING` e retorna `depositId`, `correlationId` e a `quote`. Guarde o `correlationId` — ele identifica o depósito nas próximas etapas.
+
+### 3. Aprovar o depósito (comprar a stablecoin)
+
+POST `/api/v1/stablecoin/deposit/approve`
+
+```json
+{ "correlationId": "my-unique-id" }
+```
+
+A aprovação **debita o saldo em BRL da conta da sua empresa** (a `companyBankAccount` da subconta), converte para stablecoin e envia para a carteira de destino. O status passa para `PROCESSING`. Não há cobrança Pix para um cliente pagar — o débito acontece na própria conta no momento da aprovação.
+
+### 4. Acompanhar a conclusão
+
+Quando a stablecoin é entregue na blockchain, você recebe o webhook `STABLECOIN_DEPOSIT_COMPLETED` (com o `txHash` da transação on-chain). Em caso de falha, recebe `STABLECOIN_DEPOSIT_FAILED`.
+
+Você também pode consultar o status a qualquer momento:
+
+GET `/api/v1/stablecoin/deposit/find?correlationId=my-unique-id`
+
+## Estados do depósito
+
+O depósito percorre os seguintes status:
+
+| Status | Significado |
+| --- | --- |
+| `CREATED` | Depósito recém-criado |
+| `PENDING` | Criado; aguardando a aprovação |
+| `PROCESSING` | Aprovado; liquidação on-chain em andamento |
+| `COMPLETED` | Stablecoin entregue na blockchain (com `txHash`) |
+| `FAILED` | Falhou em alguma etapa |
+
+```mermaid
+flowchart LR
+  CREATED --> PENDING --> PROCESSING --> COMPLETED
+  PENDING --> FAILED
+  PROCESSING --> FAILED
+```

--- a/docs/stablecoin/stablecoin-limits.md
+++ b/docs/stablecoin/stablecoin-limits.md
@@ -1,0 +1,38 @@
+---
+id: stablecoin-limits
+sidebar_position: 6
+title: Limites
+tags:
+  - stablecoin
+  - api
+---
+
+## Limites do Stablecoin
+
+Os limites de stablecoin estão vinculados ao **KYB** (Know Your Business) da sua empresa e são validados a cada depósito.
+
+## Subconta ativa (KYB)
+
+Para criar qualquer depósito, sua empresa precisa de uma subconta de stablecoin com status `CONFIRMED`. Enquanto o KYB não estiver aprovado, a criação do depósito retorna `400`:
+
+```json
+{ "error": "Nenhuma subconta de stablecoin ativa. É necessário um KYB, entre em contato com o suporte." }
+```
+
+## Limite padrão
+
+O limite padrão é de **R$ 120.000,00 por mês** (120k BRL/mês). A cada depósito, a Woovi valida o valor contra o limite disponível da sua conta; quando um depósito excede o limite, a requisição é rejeitada e o motivo é retornado na resposta de erro.
+
+## Como aumentar o limite
+
+Para aumentar o limite é necessário comunicar o suporte. Será necessário um **KYC estendido**, com informações referentes à capacidade financeira e comprovantes de endereço.
+
+## Valor mínimo
+
+O campo `value` do depósito deve ser um número positivo, em centavos de BRL. Valores inválidos retornam:
+
+```json
+{ "error": "value must be a positive number (in cents)" }
+```
+
+> Os valores exatos de limite dependem do nível de KYB da sua empresa. Para aumentar limites, entre em contato com o suporte.

--- a/docs/stablecoin/stablecoin-webhooks.md
+++ b/docs/stablecoin/stablecoin-webhooks.md
@@ -1,0 +1,69 @@
+---
+id: stablecoin-webhooks
+sidebar_position: 4
+title: Webhooks
+tags:
+  - stablecoin
+  - api
+---
+
+## Webhooks do Stablecoin
+
+Os webhooks notificam sua aplicação sobre o resultado do depósito de stablecoin. Caso ainda não saiba como cadastrar webhooks na plataforma, veja o nosso [tutorial](../webhook/platform/webhook-platform-api.mdx).
+
+Existem dois eventos:
+
+| Evento | Quando ocorre |
+| --- | --- |
+| `STABLECOIN_DEPOSIT_COMPLETED` | A stablecoin foi entregue na blockchain |
+| `STABLECOIN_DEPOSIT_FAILED` | O depósito falhou em alguma etapa |
+
+O objeto enviado contém `stableDeposit` (os dados do depósito) e `company` (sua empresa). O campo `correlationID` corresponde ao identificador único que você enviou ao criar o depósito.
+
+### STABLECOIN_DEPOSIT_COMPLETED
+
+Disparado quando a stablecoin é entregue com sucesso na carteira de destino. O campo `txHash` traz o hash da transação on-chain.
+
+```json
+{
+  "event": "STABLECOIN_DEPOSIT_COMPLETED",
+  "stableDeposit": {
+    "id": "6650abc1234def567890aaaa",
+    "status": "COMPLETED",
+    "inputAmount": 10000,
+    "inputCurrency": "BRL",
+    "outputAmount": 18.45,
+    "outputCurrency": "USDT",
+    "txHash": "0x587a660fe5349113801ec77fa6f79ae096e53a67bfa7f9098f096d1b9575fa53",
+    "correlationID": "my-unique-id",
+    "completedAt": "2026-06-05T12:00:00.000Z"
+  },
+  "company": {
+    "name": "Acme Corp"
+  }
+}
+```
+
+### STABLECOIN_DEPOSIT_FAILED
+
+Disparado quando o depósito falha. Os campos `reason` e `errorCode` indicam o motivo.
+
+```json
+{
+  "event": "STABLECOIN_DEPOSIT_FAILED",
+  "stableDeposit": {
+    "id": "6650abc1234def567890aaaa",
+    "status": "FAILED",
+    "inputAmount": 10000,
+    "inputCurrency": "BRL",
+    "outputCurrency": "USDT",
+    "correlationID": "my-unique-id",
+    "failedAt": "2026-06-05T12:00:00.000Z"
+  },
+  "company": {
+    "name": "Acme Corp"
+  },
+  "reason": "Deposit failed",
+  "errorCode": "DEPOSIT-FAILED"
+}
+```

--- a/docs/stablecoin/stablecoin-what-is-it.md
+++ b/docs/stablecoin/stablecoin-what-is-it.md
@@ -1,0 +1,56 @@
+---
+id: stablecoin-what-is-it
+sidebar_position: 1
+title: O que é o Stablecoin?
+tags:
+  - stablecoin
+  - api
+---
+
+O Stablecoin da Woovi permite que sua empresa converta reais (BRL) em stablecoins — como **USDT** e **USDC**. A partir do saldo em BRL da conta da sua empresa, o valor é entregue, já convertido, em stablecoin na carteira de destino, na rede escolhida.
+
+É ideal para quem precisa de saldo em dólar digital de forma simples.
+
+:::warning Aviso importante
+Os serviços de ativos virtuais são prestados pelas **PSAVs** (Prestadoras de Serviços de Ativos Virtuais) parceiras da Woovi. A Woovi não realiza custódia ou liquidação de ativos virtuais.
+
+Verifique o endereço da carteira de destino com atenção. Após a confirmação, a operação é **irreversível** e não pode ser reembolsada.
+:::
+
+## Funcionamento
+
+O funcionamento é composto por 2 etapas principais:
+
+1. **Criar um depósito**
+2. **Aprovar o depósito (compra do USDT)**, que debita o saldo em BRL da conta, dispara a liquidação on-chain e entrega a stablecoin
+
+Resumindo: você cria um depósito e o aprova; a Woovi debita o saldo em BRL da conta da empresa, converte em stablecoin e envia para a carteira de destino na blockchain.
+
+## Stablecoins e redes suportadas
+
+Nem todo ativo está disponível em todas as redes. A matriz suportada é:
+
+| Stablecoin | Redes |
+| --- | --- |
+| `USDT` | `POLYGON`, `ETHEREUM`, `CELO`, `TRON` |
+| `USDC` | `POLYGON`, `ETHEREUM`, `BASE`, `CELO` |
+
+Quando o campo `network` é omitido, o padrão é `POLYGON`. Enviar uma combinação de ativo/rede fora da matriz acima retorna `400`.
+
+## Pré-requisito: KYB
+
+Para criar depósitos, sua empresa precisa ter uma **subconta de stablecoin** com status `CONFIRMED`, ou seja, com o KYB (Know Your Business) aprovado — parte da infraestrutura de [BaaS](https://developers.woovi.com/docs/category/baas) da Woovi. Sem uma subconta ativa, a criação do depósito é rejeitada com `400` e a mensagem:
+
+```json
+{ "error": "Nenhuma subconta de stablecoin ativa. É necessário um KYB, entre em contato com o suporte." }
+```
+
+Para iniciar o processo de KYB, entre em contato com o suporte.
+
+## Próximos passos
+
+- [Endpoints](./stablecoin-endpoints.md) — todas as rotas da API
+- [Fluxo passo a passo](./stablecoin-flow.md) — do depósito à entrega on-chain
+- [Webhooks](./stablecoin-webhooks.md) — como ser notificado
+- [Taxas](./stablecoin-fees.md)
+- [Limites](./stablecoin-limits.md)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -110,6 +110,11 @@ module.exports = {
     ],
   ],
   themeConfig: {
+    mermaid: {
+      options: {
+        securityLevel: 'loose',
+      },
+    },
     navbar: {
       title: 'Woovi Developers',
       logo: {


### PR DESCRIPTION
## What

Adds the **Stablecoin** documentation section to the developer portal (`docs/stablecoin/`):

- **O que é o Stablecoin?** — overview + PSAV disclaimer (serviços prestados por PSAVs parceiras; Woovi não custodia/liquida; operação irreversível; conferir a carteira de destino)
- **Fluxo passo a passo** — step-by-step + Mermaid diagrams (contas PJ / SubAccount / BaaS, e o exemplo de cobrança)
- **Endpoints**, **Webhooks**, **Taxas**, **Limites**

## Notes

- The flow reflects the **real behaviour**: `POST /deposit` creates the deposit (`PENDING`); `POST /deposit/approve` **debits the company's BRL account** and delivers the stablecoin on-chain. There is no "customer pays a Pix QR" step.
- Only **USDT** and **USDC** are documented (**BRLA omitted** from the public docs).
- `docusaurus.config.js`: enables Mermaid `securityLevel: 'loose'` so the clickable **BaaS** node in the flow diagram links to the BaaS category.

> The companion OpenAPI spec for these endpoints landed in #686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)