### PR TITLE
feat(docs) add funds recovery (MED) API docs

### DIFF
--- a/docs/funds-recovery/_category_.json
+++ b/docs/funds-recovery/_category_.json
@@ -1,0 +1,13 @@
+{
+  "label": "Recuperação de fundos (MED)",
+  "collapsible": true,
+  "collapsed": true,
+  "className": "red",
+  "link": {
+    "type": "generated-index",
+    "title": "Recuperação de fundos (MED) visão geral"
+  },
+  "customProps": {
+    "description": "Recuperação de fundos (MED) documentação"
+  }
+}

--- a/docs/funds-recovery/funds-recovery-cancel-api.mdx
+++ b/docs/funds-recovery/funds-recovery-cancel-api.mdx
@@ -1,0 +1,87 @@
+---
+id: funds-recovery-cancel-api
+sidebar_position: 4
+title: Como cancelar uma recuperação de fundos (MED) usando a API?
+tags:
+  - funds-recovery
+  - med
+  - api
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Para cancelar uma recuperação de fundos (MED) usando a API, você deverá fazer uma chamada POST para o _endpoint_ `/api/v1/funds-recovery/{id}/cancel`, usando o `dictId` retornado na [criação](./funds-recovery-create-api.mdx).
+
+A requisição não precisa de `BODY`.
+
+:::caution
+Só é possível cancelar recuperações de fundos **abertas pela sua conta** e que ainda não atingiram um status final (`COMPLETED` ou `CANCELLED`).
+:::
+
+## Exemplo
+
+Se tudo ocorreu bem, o _status code_ da requisição será `200` e no `body` da resposta retornaremos a recuperação de fundos cancelada:
+
+```json
+{
+  "rootTransactionId": "E31680151202606101530AbCdEf12345",
+  "situationType": "SCAM",
+  "reportDetails": "Pagamento realizado para um falso vendedor. Após o pagamento, o vendedor parou de responder e não entregou o produto.",
+  "dictId": "3e760cd5-39b2-45da-8ab6-b212cf205568",
+  "status": "CANCELLED",
+  "direction": "SENT",
+  "reporterParticipant": "31680151",
+  "creationTime": "2026-06-11T00:30:00.000Z",
+  "lastModified": "2026-06-11T01:10:00.000Z",
+  "createdAt": "2026-06-11T00:30:00.000Z",
+  "updatedAt": "2026-06-11T01:10:00.000Z"
+}
+```
+
+## Possíveis erros
+
+| Status | Motivo                                                                                          |
+| ------ | ------------------------------------------------------------------------------------------------ |
+| `400`  | O `id` informado não é um UUID válido                                                             |
+| `401`  | `AppID` inválido ou ausente                                                                       |
+| `403`  | Sua conta não possui a funcionalidade MED API ou o AppID não possui o escopo necessário           |
+| `404`  | Recuperação de fundos não encontrada para a sua conta                                             |
+| `422`  | A recuperação de fundos já está em um status final ou o cancelamento foi recusado pelo Banco Central |
+
+Em caso de erro, o body da resposta terá o formato:
+
+```json
+{
+  "error": "Cannot cancel: FundsRecovery is already in terminal status COMPLETED"
+}
+```
+
+### Exemplos em código
+
+<Tabs>
+  <TabItem value="shell-curl" label="Shell + cURL" default>
+
+```sh
+curl --request POST \
+    --url https://api.woovi.com/api/v1/funds-recovery/3e760cd5-39b2-45da-8ab6-b212cf205568/cancel \
+    --header 'Authorization: AUTHORIZATION'
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript + Fetch" default>
+
+```js
+fetch(
+  'https://api.woovi.com/api/v1/funds-recovery/3e760cd5-39b2-45da-8ab6-b212cf205568/cancel',
+  {
+    method: 'POST',
+    headers: {
+      Authorization: 'AUTHORIZATION',
+    },
+  },
+).then((res) => res.json());
+```
+
+  </TabItem>
+</Tabs>

--- a/docs/funds-recovery/funds-recovery-create-api.mdx
+++ b/docs/funds-recovery/funds-recovery-create-api.mdx
@@ -1,0 +1,117 @@
+---
+id: funds-recovery-create-api
+sidebar_position: 2
+title: Como abrir uma recuperação de fundos (MED) usando a API?
+tags:
+  - funds-recovery
+  - med
+  - api
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Para abrir uma recuperação de fundos (MED) usando a API, você deverá fazer uma chamada POST para o _endpoint_ `/api/v1/funds-recovery`, autenticando com o seu `AppID` no header `Authorization`.
+
+Como parte do `BODY` da requisição, esperamos o envio dos seguintes itens:
+
+- **`transactionEndToEndId`**: O `endToEndId` da transação Pix enviada pela sua conta que você deseja recuperar.
+- **`situationType`**: O tipo de situação que motivou a recuperação de fundos. Os valores possíveis são:
+  - `SCAM`: golpe (ex: falsa venda, falso boleto, engenharia social)
+  - `ACCOUNT_TAKEOVER`: invasão de conta
+  - `COERCION`: coação (ex: sequestro, extorsão)
+  - `FRAUDULENT_ACCESS`: acesso fraudulento às credenciais
+  - `OTHER`: outro tipo de fraude
+  - `UNKNOWN`: tipo de fraude desconhecido
+- **`details`**: A descrição detalhada do ocorrido. Quanto mais contexto, melhor para a análise.
+
+:::caution
+Só é possível abrir **uma** recuperação de fundos por transação. A transação precisa ter sido enviada pela sua conta e não pode ter sido rejeitada.
+:::
+
+## Exemplo
+
+O body da sua requisição será semelhante a este exemplo:
+
+```json
+{
+  "transactionEndToEndId": "E31680151202606101530AbCdEf12345",
+  "situationType": "SCAM",
+  "details": "Pagamento realizado para um falso vendedor. Após o pagamento, o vendedor parou de responder e não entregou o produto."
+}
+```
+
+Após efetuar a requisição, se tudo ocorreu bem, o _status code_ da requisição será `201` e no `body` da resposta retornaremos a recuperação de fundos criada:
+
+```json
+{
+  "rootTransactionId": "E31680151202606101530AbCdEf12345",
+  "situationType": "SCAM",
+  "reportDetails": "Pagamento realizado para um falso vendedor. Após o pagamento, o vendedor parou de responder e não entregou o produto.",
+  "dictId": "3e760cd5-39b2-45da-8ab6-b212cf205568",
+  "status": "CREATED",
+  "direction": "SENT",
+  "reporterParticipant": "31680151",
+  "creationTime": "2026-06-11T00:30:00.000Z",
+  "lastModified": "2026-06-11T00:30:00.000Z",
+  "events": [],
+  "createdAt": "2026-06-11T00:30:00.000Z",
+  "updatedAt": "2026-06-11T00:30:00.000Z"
+}
+```
+
+:::tip
+Guarde o campo **`dictId`** — ele é o identificador da recuperação de fundos e será usado nos endpoints de [consulta](./funds-recovery-get-api.mdx) e [cancelamento](./funds-recovery-cancel-api.mdx).
+:::
+
+## Possíveis erros
+
+| Status | Motivo                                                                                  |
+| ------ | ---------------------------------------------------------------------------------------- |
+| `400`  | Body inválido (campo faltando ou `situationType` fora dos valores aceitos)               |
+| `401`  | `AppID` inválido ou ausente                                                               |
+| `403`  | Sua conta não possui a funcionalidade MED API ou o AppID não possui o escopo necessário   |
+| `404`  | Transação não encontrada para a sua conta                                                 |
+| `422`  | Já existe uma recuperação de fundos para a transação, a transação foi rejeitada ou o pedido foi recusado pelo Banco Central |
+
+Em caso de erro, o body da resposta terá o formato:
+
+```json
+{
+  "error": "FundsRecovery already exists for transaction E31680151202606101530AbCdEf12345"
+}
+```
+
+### Exemplos em código
+
+<Tabs>
+  <TabItem value="shell-curl" label="Shell + cURL" default>
+
+```sh
+curl --request POST \
+    --url https://api.woovi.com/api/v1/funds-recovery \
+    --header 'Authorization: AUTHORIZATION' \
+    --header 'content-type: application/json' \
+    --data '{"transactionEndToEndId": "E31680151202606101530AbCdEf12345", "situationType": "SCAM", "details": "Pagamento realizado para um falso vendedor."}'
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript + Fetch" default>
+
+```js
+fetch('https://api.woovi.com/api/v1/funds-recovery', {
+  method: 'POST',
+  body: JSON.stringify({
+    transactionEndToEndId: 'E31680151202606101530AbCdEf12345',
+    situationType: 'SCAM',
+    details: 'Pagamento realizado para um falso vendedor.',
+  }),
+  headers: {
+    Authorization: 'AUTHORIZATION',
+    'Content-Type': 'application/json',
+  },
+}).then((res) => res.json());
+```
+
+  </TabItem>
+</Tabs>

--- a/docs/funds-recovery/funds-recovery-get-api.mdx
+++ b/docs/funds-recovery/funds-recovery-get-api.mdx
@@ -1,0 +1,83 @@
+---
+id: funds-recovery-get-api
+sidebar_position: 3
+title: Como consultar uma recuperação de fundos (MED) usando a API?
+tags:
+  - funds-recovery
+  - med
+  - api
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Para consultar uma recuperação de fundos (MED) usando a API, você deverá fazer uma chamada GET para o _endpoint_ `/api/v1/funds-recovery/{id}`, usando o `dictId` retornado na [criação](./funds-recovery-create-api.mdx).
+
+Use este endpoint para acompanhar o andamento da recuperação de fundos através do campo `status` — veja o [ciclo de vida](./funds-recovery.md#ciclo-de-vida) completo.
+
+## Exemplo
+
+Se tudo ocorreu bem, o _status code_ da requisição será `200` e no `body` da resposta retornaremos a recuperação de fundos:
+
+```json
+{
+  "rootTransactionId": "E31680151202606101530AbCdEf12345",
+  "situationType": "SCAM",
+  "reportDetails": "Pagamento realizado para um falso vendedor. Após o pagamento, o vendedor parou de responder e não entregou o produto.",
+  "dictId": "3e760cd5-39b2-45da-8ab6-b212cf205568",
+  "status": "AWAITING_ANALYSIS",
+  "direction": "SENT",
+  "reporterParticipant": "31680151",
+  "creationTime": "2026-06-11T00:30:00.000Z",
+  "lastModified": "2026-06-11T00:35:00.000Z",
+  "events": [
+    {
+      "id": "f3a1c9d2-8b47-4e6a-9c21-5d7e0a4b8f13",
+      "event": "AWAITING_ANALYSIS",
+      "timestamp": "2026-06-11T00:35:00.000Z"
+    }
+  ],
+  "createdAt": "2026-06-11T00:30:00.000Z",
+  "updatedAt": "2026-06-11T00:35:00.000Z"
+}
+```
+
+O campo `events` traz o histórico de eventos da recuperação de fundos, em ordem cronológica.
+
+## Possíveis erros
+
+| Status | Motivo                                                                                |
+| ------ | -------------------------------------------------------------------------------------- |
+| `400`  | O `id` informado não é um UUID válido                                                   |
+| `401`  | `AppID` inválido ou ausente                                                             |
+| `403`  | Sua conta não possui a funcionalidade MED API ou o AppID não possui o escopo necessário |
+| `404`  | Recuperação de fundos não encontrada para a sua conta                                   |
+
+### Exemplos em código
+
+<Tabs>
+  <TabItem value="shell-curl" label="Shell + cURL" default>
+
+```sh
+curl --request GET \
+    --url https://api.woovi.com/api/v1/funds-recovery/3e760cd5-39b2-45da-8ab6-b212cf205568 \
+    --header 'Authorization: AUTHORIZATION'
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript + Fetch" default>
+
+```js
+fetch(
+  'https://api.woovi.com/api/v1/funds-recovery/3e760cd5-39b2-45da-8ab6-b212cf205568',
+  {
+    method: 'GET',
+    headers: {
+      Authorization: 'AUTHORIZATION',
+    },
+  },
+).then((res) => res.json());
+```
+
+  </TabItem>
+</Tabs>

--- a/docs/funds-recovery/funds-recovery.md
+++ b/docs/funds-recovery/funds-recovery.md
@@ -1,0 +1,46 @@
+---
+id: funds-recovery
+sidebar_position: 1
+title: O que é a Recuperação de fundos (MED)?
+tags:
+  - funds-recovery
+  - med
+  - api
+---
+
+A **Recuperação de fundos** (_Funds Recovery_) é a implementação do **MED** (Mecanismo Especial de Devolução) do Banco Central. Ela permite que você solicite a devolução de uma transação Pix enviada pela sua conta em casos de **golpe ou fraude**.
+
+Ao abrir uma recuperação de fundos, o Banco Central rastreia o caminho do dinheiro entre as instituições participantes do Pix e abre solicitações de devolução nas contas por onde os fundos passaram. Os valores localizados são bloqueados nas contas de destino e devolvidos para a sua conta.
+
+## Pré-requisitos
+
+Para usar a API de recuperação de fundos você precisa:
+
+- Ter a funcionalidade **MED API** habilitada na sua conta. Caso ainda não tenha, entre em contato com o nosso suporte.
+- Um [AppID](../apis/api-getting-started.md) para autenticar as requisições, enviado no header `Authorization`.
+
+## Endpoints
+
+| Endpoint                                                                       | Método | Descrição                                |
+| ------------------------------------------------------------------------------ | ------ | ---------------------------------------- |
+| [`/api/v1/funds-recovery`](./funds-recovery-create-api.mdx)                     | POST   | Abrir uma recuperação de fundos           |
+| [`/api/v1/funds-recovery/{id}`](./funds-recovery-get-api.mdx)                   | GET    | Consultar uma recuperação de fundos       |
+| [`/api/v1/funds-recovery/{id}/cancel`](./funds-recovery-cancel-api.mdx)         | POST   | Cancelar uma recuperação de fundos        |
+
+## Ciclo de vida
+
+Uma recuperação de fundos passa pelos seguintes status:
+
+- **`CREATED`**: a recuperação de fundos foi registrada no Banco Central.
+- **`TRACKED`**: o rastreamento do caminho do dinheiro foi concluído.
+- **`AWAITING_ANALYSIS`**: aguardando a análise do Banco Central.
+- **`ANALYSED`**: análise concluída; as solicitações de devolução são abertas nas instituições por onde os fundos passaram.
+- **`REFUNDING`**: devoluções em andamento.
+- **`COMPLETED`**: processo concluído. Os valores recuperados foram devolvidos.
+- **`CANCELLED`**: a recuperação de fundos foi cancelada.
+
+`COMPLETED` e `CANCELLED` são status finais — após atingi-los a recuperação de fundos não pode mais ser alterada.
+
+:::info
+O valor devolvido depende do saldo encontrado nas contas rastreadas. A recuperação pode ser **total**, **parcial** ou pode não haver fundos disponíveis para devolução.
+:::


### PR DESCRIPTION
## What

Adds public documentation for the Funds Recovery (MED) REST API, so partners can integrate and open funds recoveries via API.

### Guide pages

New section `docs/funds-recovery/` with:

- **Overview** — what funds recovery (MED) is, prerequisites (MED API feature flag + AppID), endpoint list and status lifecycle (`CREATED` → `TRACKED` → `AWAITING_ANALYSIS` → `ANALYSED` → `REFUNDING` → `COMPLETED` / `CANCELLED`)
- **`POST /api/v1/funds-recovery`** — open a funds recovery: request fields (`transactionEndToEndId`, `situationType` enum, `details`), response example, error table (400/401/403/404/422)
- **`GET /api/v1/funds-recovery/{id}`** — query by `dictId`, including the `events` history
- **`POST /api/v1/funds-recovery/{id}/cancel`** — cancel rules (only own, non-terminal status)

All pages follow the existing refund/dispute doc patterns (pt-BR, cURL + Fetch tabs).

### API reference (`/api`)

Updated `src/swaggers/woovi.{json,yml}` and `src/components/ApiExplorer/endpoints.ts` with the three funds recovery endpoints, generated from the new OpenAPI sources in the monorepo — companion PR: entria/woovi#101025.

## How to validate

`pnpm build:ptbr` passes; no new broken links/anchors introduced.
