### PR TITLE
docs(stablecoin): subaccount KYB webhooks + create endpoint

### DIFF
--- a/docs/stablecoin/stablecoin-endpoints.md
+++ b/docs/stablecoin/stablecoin-endpoints.md
@@ -17,7 +17,8 @@ Todas as rotas ficam sob `/api/v1/stablecoin/` e exigem autenticação com o seu
 | --- | --- |
 | `STABLECOIN_DEPOSIT_CREATE` | `quote`, `deposit`, `deposit/approve` |
 | `STABLECOIN_DEPOSIT_LIST` | `deposit/find`, `deposit` (listar) |
-| `STABLECOIN_SUBACCOUNT_LIST` | `subaccount`, `subaccount/{subAccountId}` |
+| `STABLECOIN_SUBACCOUNT_CREATE` | `subaccount` (POST — solicitar KYB) |
+| `STABLECOIN_SUBACCOUNT_LIST` | `subaccount` (listar), `subaccount/{subAccountId}` |
 
 > A URL base de produção é `https://api.woovi.com`. Caso o App não tenha o escopo necessário, a resposta é `401` com `Application is missing required scope: ...`.
 
@@ -189,6 +190,54 @@ Lista os depósitos da empresa autenticada (paginado).
   "skip": 0
 }
 ```
+
+### Solicitar uma subconta (KYB)
+
+POST `/api/v1/stablecoin/subaccount`
+
+Solicita a criação de uma subconta de stablecoin para a empresa autenticada, reaproveitando os dados de KYC já presentes no `accountRegister` informado. A subconta no provedor é criada imediatamente e um registro `StableSubAccount` é persistido com status `IN_REVIEW` enquanto o KYB é processado.
+
+O processamento do KYB é **assíncrono**: quando ele é resolvido, a empresa recebe um webhook `STABLECOIN_SUBACCOUNT_CONFIRMED` ou `STABLECOIN_SUBACCOUNT_REJECTED` (veja [Webhooks](./stablecoin-webhooks.md)). Somente após o `STABLECOIN_SUBACCOUNT_CONFIRMED` a subconta pode ser usada em `POST /api/v1/stablecoin/deposit`.
+
+A rota é **idempotente** por `accountRegisterId`: uma chamada repetida retorna a subconta já existente (HTTP `200`), enquanto a primeira chamada (que cria) retorna HTTP `201`. Exige o escopo `STABLECOIN_SUBACCOUNT_CREATE`.
+
+Body:
+
+| campo | tipo | obrigatório | descrição |
+| --- | --- | --- | --- |
+| `accountRegisterId` | string | sim | id do `accountRegister` cujos dados de KYC serão usados no KYB |
+| `companyBankAccountId` | string | não | conta bancária da empresa a vincular; usa a conta padrão da empresa quando omitida |
+
+```bash
+curl --request POST \
+  --url https://api.woovi.com/api/v1/stablecoin/subaccount \
+  --header 'Authorization: <SEU_APP_ID>' \
+  --header 'content-type: application/json' \
+  --data '{
+    "accountRegisterId": "6650abc1234def567890aaaa"
+  }'
+```
+
+Resposta (`201` na criação, `200` quando a subconta já existia):
+
+```json
+{
+  "subAccountId": "sub_01HZ...",
+  "status": "IN_REVIEW",
+  "correlationId": "0f2c8d6a-1b3e-4f5a-9c7d-8e2a1b4c6d8f"
+}
+```
+
+Erros comuns:
+
+```json
+{ "error": "accountRegisterId is required" }
+{ "error": "INVALID_ACCOUNT_REGISTER_ID", "correlationId": "..." }
+{ "error": "ACCOUNT_REGISTER_NOT_FOUND", "correlationId": "..." }
+{ "error": "ACCOUNT_REGISTER_MISSING_OFFICIAL_NAME", "correlationId": "..." }
+```
+
+> Erros que o chamador pode corrigir (id inválido, `accountRegister` inexistente ou sem dados obrigatórios) retornam `400`. Falhas no provedor ou na persistência retornam `502` (ex.: `AVENIA_SUBACCOUNT_CREATE_FAILED`), indicando que a chamada pode ser repetida.
 
 ### Listar subcontas
 

--- a/docs/stablecoin/stablecoin-webhooks.md
+++ b/docs/stablecoin/stablecoin-webhooks.md
@@ -67,3 +67,60 @@ Disparado quando o depósito falha. Os campos `reason` e `errorCode` indicam o m
   "errorCode": "DEPOSIT-FAILED"
 }
 ```
+
+## Webhooks da Subconta (KYB)
+
+Quando você solicita uma subconta de stablecoin (KYB) via `POST /api/v1/stablecoin/subaccount`, ela é criada com status `IN_REVIEW` enquanto a análise é processada. O resultado **não é síncrono**: assim que o KYB é resolvido pelo provedor, sua aplicação recebe um destes eventos.
+
+| Evento | Quando ocorre |
+| --- | --- |
+| `STABLECOIN_SUBACCOUNT_CONFIRMED` | O KYB foi aprovado e a subconta está apta a receber depósitos |
+| `STABLECOIN_SUBACCOUNT_REJECTED` | O KYB foi recusado; a subconta não pode operar |
+
+O objeto enviado contém `stableSubAccount` (os dados da subconta) e `company` (sua empresa). Use o campo `stableSubAccount.id` para conciliar com o `subAccountId` retornado na criação.
+
+### STABLECOIN_SUBACCOUNT_CONFIRMED
+
+Disparado quando o KYB é aprovado. A partir deste momento a subconta tem `status: "CONFIRMED"` e pode ser usada em `POST /api/v1/stablecoin/deposit`. O campo `confirmedAt` traz o instante da confirmação.
+
+```json
+{
+  "event": "STABLECOIN_SUBACCOUNT_CONFIRMED",
+  "stableSubAccount": {
+    "id": "6650abc1234def567890aaaa",
+    "status": "CONFIRMED",
+    "subAccountId": "sub_01HZ...",
+    "accountRegisterId": "6650def1234abc567890bbbb",
+    "confirmedAt": "2026-06-05T12:00:00.000Z"
+  },
+  "company": {
+    "id": "6650aaa1234bbb567890cccc",
+    "name": "Acme Corp",
+    "taxID": "12345678000199"
+  }
+}
+```
+
+### STABLECOIN_SUBACCOUNT_REJECTED
+
+Disparado quando o KYB é recusado. Os campos opcionais `reason` e `rejectionLabels` indicam o motivo da recusa, quando disponíveis.
+
+```json
+{
+  "event": "STABLECOIN_SUBACCOUNT_REJECTED",
+  "stableSubAccount": {
+    "id": "6650abc1234def567890aaaa",
+    "status": "REJECTED",
+    "subAccountId": "sub_01HZ...",
+    "accountRegisterId": "6650def1234abc567890bbbb",
+    "rejectedAt": "2026-06-05T12:00:00.000Z"
+  },
+  "company": {
+    "id": "6650aaa1234bbb567890cccc",
+    "name": "Acme Corp",
+    "taxID": "12345678000199"
+  },
+  "reason": "Document verification failed",
+  "rejectionLabels": ["INVALID_DOCUMENT"]
+}
+```


### PR DESCRIPTION
## What

Documents the stablecoin subaccount (KYB) flow on developers.woovi.com.

- **Webhooks page** — adds a new "Webhooks da Subconta (KYB)" section with `STABLECOIN_SUBACCOUNT_CONFIRMED` and `STABLECOIN_SUBACCOUNT_REJECTED`, each with a full payload example (`stableSubAccount` + `company`).
- **Endpoints page** — documents `POST /api/v1/stablecoin/subaccount` ("Solicitar uma subconta (KYB)"): request body (`accountRegisterId`, optional `companyBankAccountId`), idempotency (201 create / 200 existing), the async webhook outcome, and 400 vs 502 error mapping. Adds the `STABLECOIN_SUBACCOUNT_CREATE` scope to the scope table.

## Why

The subaccount creation endpoint shipped in woovi-stablecoin (#193) but was undocumented, and the resulting KYB webhooks were not described for merchants.

Payload shapes mirror `buildStableSubAccountWebhookPayload` / `sendCompanyWebhooks` and the `requestStableSubAccountActivation` result in woovi-stablecoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)