### PR TITLE
docs: move Pix Automático sandbox para categoria Ambiente de Teste

### DIFF
--- a/docs/test-environment/pix-automatic-in-sandbox.md
+++ b/docs/test-environment/pix-automatic-in-sandbox.md
@@ -1,6 +1,5 @@
 ---
 id: pix-automatic-in-sandbox
-sidebar_position: 19
 title: Pix Automatico em sandbox
 tags:
   - pix-automatic

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -105,6 +105,10 @@ module.exports = {
             from: '/docs/getting-started',
             to: '/docs/intro/getting-started',
           },
+          {
+            from: '/docs/pix-automatic/pix-automatic-in-sandbox',
+            to: '/docs/test-environment/pix-automatic-in-sandbox',
+          },
         ],
       },
     ],


### PR DESCRIPTION
## O que muda

Move o guia **Pix Automático em sandbox** para a categoria **Ambiente de Teste** (`/docs/category/ambiente-de-teste`).

- Move `docs/pix-automatic/pix-automatic-in-sandbox.md` → `docs/test-environment/pix-automatic-in-sandbox.md`
- Remove o `sidebar_position` antigo (na nova categoria ordena alfabeticamente, ficando após a visão geral e a "Conta de Teste")
- Adiciona redirect `/docs/pix-automatic/pix-automatic-in-sandbox` → `/docs/test-environment/pix-automatic-in-sandbox` para não quebrar links existentes
- Pasta `docs/pix-automatic/` mantida (possui outros docs)

## Validação
- Sidebar é `autogenerated` por pasta → mover o arquivo reassocia à categoria
- `node --check docusaurus.config.js`: OK
- Sem links internos para o doc; i18n usa fallback do default (nada a mover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)