### PR TITLE
docs: improve basic BaaS flow guide

### DIFF
--- a/docs/apis/api-pix-key-campaign.md
+++ b/docs/apis/api-pix-key-campaign.md
@@ -15,6 +15,10 @@ Vá para `Api/Plugins` na barra lateral e clique em `Nova API/Plugin`.
 Caso você não esteja visualizando o sidebar API/Plugins é necessário ter a permissão correta, veja com o admin da sua empresa.
 :::
 
+:::info
+Atenção: Somente para clientes BaaS.
+:::
+
 ![appid-1](./__assets__/api-plugins.png)
 
 ![appid-2](./__assets__/new-api-plugin.png)

--- a/docs/payment/payment-flow.md
+++ b/docs/payment/payment-flow.md
@@ -87,3 +87,11 @@ Este documento irá ajudar a entender como criar e aprovar um pagamento pix na w
   }
 }
 ```
+
+:::warning 
+
+O DICT não deve ser utilizado para consultas cadastrais nem para finalidades diferentes da realização de transações utilizando uma chave Pix.
+
+Para mais detalhes, consulte o Manual Operacional do Diretório de Identificadores de Contas Transacionais (DICT).
+
+:::

--- a/docs/payment/payment-how-to-auto-approve.md
+++ b/docs/payment/payment-how-to-auto-approve.md
@@ -13,8 +13,6 @@ tags:
 
 O campo `autoApprove` no endpoint `POST /api/v1/payment` permite criar e aprovar um pagamento Pix em uma única requisição, eliminando a necessidade de chamar o endpoint `/api/v1/payment/approve` separadamente.
 
-> **Atenção:** O uso do `autoApprove` requer permissão especial na sua conta. Entre em contato com o suporte para ativar essa funcionalidade.
-
 ## Como usar
 
 Envie `autoApprove: true` no corpo da requisição ao criar um pagamento:


### PR DESCRIPTION
Improve the formatting and readability of the basic BaaS flow guide by organizing the content with proper headings, lists, and clearer structure.