### PR TITLE
docs(kyc): guia white-label para ocultar a logo da Woovi via ?embed=true

### DIFF
--- a/docs/baas/kyc/api-onboarding-embed.mdx
+++ b/docs/baas/kyc/api-onboarding-embed.mdx
@@ -64,6 +64,10 @@ Antes de incorporar, você precisa ter o `linkOnboarding` em mãos. Caso ainda n
 Para o schema, parâmetros e exemplos interativos do endpoint que gera o `linkOnboarding`, veja a [API Reference](https://developers.woovi.com/api#tag/kyc/POST/api/v1/kyc/onboarding).
 :::
 
+:::tip Experiência white-label (sem a logo da Woovi)
+Para uma integração white-label, você pode ocultar a logo da Woovi no topo do formulário adicionando `?embed=true` à URL de onboarding. Veja [Como ocultar a logo da Woovi no link de onboarding?](./api-onboarding-white-label.mdx).
+:::
+
 ## Opção 1 — Redirecionamento (recomendado)
 
 A forma mais simples e segura de integrar é redirecionar o merchant diretamente para o `linkOnboarding`. O merchant preenche todo o cadastro na página da Woovi e, quando terminar, você pode trazê-lo de volta via um botão no seu sistema ou consultando o status pela API.

--- a/docs/baas/kyc/api-onboarding-white-label.mdx
+++ b/docs/baas/kyc/api-onboarding-white-label.mdx
@@ -1,0 +1,82 @@
+---
+id: kyc-api-onboarding-white-label
+title: Como ocultar a logo da Woovi no link de onboarding?
+tags:
+  - api
+  - kyc
+  - onboarding
+  - embed
+  - white-label
+  - logo
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Ao incorporar o KYC Onboarding no seu produto (via [iframe, redirecionamento ou popup](./api-onboarding-embed.mdx)), você pode querer uma experiência **white-label**, sem a logo da Woovi no topo da página.
+
+Para isso, o formulário tem um **modo embedded**: basta adicionar o parâmetro de query **`?embed=true`** à URL de onboarding. Quando presente, o cabeçalho com a logo da Woovi **não é exibido**.
+
+:::info Como funciona
+O modo embedded é controlado pela própria URL. Não há configuração de conta, feature ou chamada de API extra para ativá-lo — é só o parâmetro `?embed=true`. Você pode aplicá-lo a qualquer `linkOnboarding`.
+:::
+
+## O que o `?embed=true` oculta (e o que não oculta)
+
+| Elemento | Com `?embed=true` |
+|----------|-------------------|
+| Cabeçalho com a logo da Woovi (topo da página) | **Ocultado** |
+| Formulário multi-step (dados, endereço, sócios, documentos, termos) | Inalterado |
+| Texto contratual ("WOOVI INSTITUIÇÃO DE PAGAMENTO LTDA." nos Termos) | **Mantido** — é conteúdo regulatório e não pode ser removido |
+| Link "termos de uso e política de privacidade da Woovi" | Mantido |
+| Título da aba do navegador (`Woovi \| KYC`) | Inalterado |
+
+:::caution
+O `?embed=true` remove apenas o **elemento visual de branding** (a logo no cabeçalho). As menções contratuais à Woovi nos Termos de Abertura de Conta são obrigatórias por regulação (BACEN) e permanecem no documento.
+:::
+
+## Como aplicar
+
+O `linkOnboarding` retornado pela API [`POST /api/v1/kyc/onboarding`](./api-onboarding-create.mdx) vem **sem** o parâmetro. Para o modo white-label, basta anexá-lo ao link que você recebeu:
+
+```
+https://kyc.woovi.com/onboarding/QWNjb3VudFJlZ2lzdGVyOjY5...?embed=true
+```
+
+:::tip Combinando com outros parâmetros
+Se a URL já tiver uma query string, use `&embed=true` em vez de `?embed=true`. Ex.: `...?foo=bar&embed=true`.
+:::
+
+<Tabs>
+  <TabItem value="iframe" label="Iframe" default>
+
+```html
+<iframe
+  src="https://kyc.woovi.com/onboarding/QWNjb3VudFJlZ2lzdGVyOjY5...?embed=true"
+  width="100%"
+  height="900"
+  style="border: 0; max-width: 640px;"
+  title="Cadastro KYC"
+  allow="camera; clipboard-read; clipboard-write"
+></iframe>
+```
+
+  </TabItem>
+  <TabItem value="js" label="JavaScript">
+
+```js
+// linkOnboarding recebido do seu backend (sem embed)
+const url = new URL(data.linkOnboarding);
+url.searchParams.set('embed', 'true');
+
+// Redireciona / abre em modo white-label
+window.location.href = url.toString();
+```
+
+  </TabItem>
+</Tabs>
+
+## Veja também
+
+- [Como criar um onboarding KYC via API?](./api-onboarding-create.mdx)
+- [Como incorporar o link de KYC Onboarding no seu site?](./api-onboarding-embed.mdx)


### PR DESCRIPTION
## O que

Adiciona um guia público em `docs/baas/kyc/` explicando como deixar o link de KYC Onboarding **white-label** — sem a logo da Woovi no topo — usando o parâmetro de query `?embed=true`.

## Por quê

- Parceiros BaaS que incorporam o onboarding no próprio produto (iframe/redirect) pedem uma versão sem o branding da Woovi.
- O `linkOnboarding` retornado pela API não vem com o parâmetro; o integrador precisa saber que basta anexar `?embed=true` (ou `&embed=true`) para ativar o modo embedded.
- O guia de embed atual não menciona essa opção.

## Mudanças

- **Novo:** `docs/baas/kyc/api-onboarding-white-label.mdx`
  - O que `?embed=true` oculta (logo do cabeçalho) e o que **não** oculta (texto contratual/regulatório da Woovi nos Termos e título da aba).
  - Como aplicar: anexar o parâmetro (`?`/`&embed=true`), com exemplos em iframe e JavaScript.
- **Atualizado:** `docs/baas/kyc/api-onboarding-embed.mdx` — cross-link para o novo guia.

Documentação pública, sem qualquer referência a implementação interna.