### PR TITLE
docs: publish the Anticipation REST API

### DIFF
--- a/docs/anticipation/_category_.json
+++ b/docs/anticipation/_category_.json
@@ -1,0 +1,12 @@
+{
+  "label": "Antecipação",
+  "collapsible": true,
+  "collapsed": true,
+  "link": {
+    "type": "generated-index",
+    "title": "Antecipação visão geral"
+  },
+  "customProps": {
+    "description": "Documentação da API REST de Antecipação (integração ERP/folha de pagamento)"
+  }
+}

--- a/docs/anticipation/anticipation-api-overview.mdx
+++ b/docs/anticipation/anticipation-api-overview.mdx
@@ -1,0 +1,91 @@
+---
+id: anticipation-api-overview
+title: Visão geral da API de Antecipação
+sidebar_label: Visão geral
+sidebar_position: 1
+description: Como autenticar e integrar a API REST de Antecipação da Woovi para cadastrar beneficiários e sincronizar saldos a partir do seu ERP ou folha de pagamento.
+tags:
+  - api
+  - anticipation
+  - antecipacao
+---
+
+A **API de Antecipação** permite que um sistema externo (ERP, folha de pagamento
+ou backoffice) cadastre beneficiários e sincronize os saldos antecipáveis de uma
+empresa que utiliza o produto de Antecipação da Woovi.
+
+É uma API REST no estilo OpenPix: autenticação por `app_id` no cabeçalho
+`Authorization`, corpo em JSON, valores monetários **em centavos** e escopos por
+funcionalidade.
+
+:::info
+Para utilizar esta API é necessário que a empresa possua a funcionalidade de
+Antecipação (Pix Out) habilitada. Caso contrário, as requisições retornam `403`.
+:::
+
+## Ambiente e URL base
+
+A API de Antecipação usa os mesmos hosts das demais APIs Woovi:
+
+| Ambiente | URL base |
+| --- | --- |
+| Produção | `https://api.woovi.com` |
+| Sandbox (testes) | `https://api.woovi-sandbox.com` |
+
+Todos os endpoints ficam sob o prefixo `/api/v1/anticipation`.
+
+## Autenticação
+
+A autenticação segue o mesmo modelo das demais APIs Woovi: um **App ID** enviado
+no cabeçalho `Authorization`.
+
+1. Crie uma aplicação em [app.woovi.com](https://app.woovi.com) e copie o `app_id`.
+2. Envie-o no cabeçalho `Authorization` de toda requisição.
+3. A empresa é resolvida a partir do `app_id` — você nunca informa o `companyId`.
+
+```sh
+Authorization: {SEU_APP_ID}
+Content-Type: application/json
+```
+
+Além do `app_id`, a autenticação valida:
+
+- **IP allowlist** — se a aplicação tiver lista de IPs configurada, o IP de
+  origem precisa estar liberado.
+- **Escopo** — a aplicação precisa possuir o escopo exigido pelo endpoint.
+- **Funcionalidade** — a empresa precisa ter Antecipação (Pix Out) habilitada.
+
+### Escopos
+
+| Escopo | Permite |
+| --- | --- |
+| `anticipation.beneficiary.write` | Cadastrar, ativar e desativar beneficiários |
+| `anticipation.balance.write` | Sincronizar saldos de beneficiários em lote |
+
+## Convenções
+
+- **Valores monetários** são sempre inteiros **em centavos** (ex.: `10000` = R$ 100,00).
+- **`taxID`** (chave de pagamento do beneficiário) pode ser CPF ou CNPJ, com ou
+  sem máscara — os dígitos são normalizados no servidor.
+- Datas são retornadas como strings **ISO 8601**.
+
+## Endpoints
+
+| Método | Endpoint | Escopo |
+| --- | --- | --- |
+| `POST` | `/api/v1/anticipation/beneficiary` | `anticipation.beneficiary.write` |
+| `POST` | `/api/v1/anticipation/balance/batch` | `anticipation.balance.write` |
+| `POST` | `/api/v1/anticipation/beneficiary/{taxID}/activate` | `anticipation.beneficiary.write` |
+| `POST` | `/api/v1/anticipation/beneficiary/{taxID}/deactivate` | `anticipation.beneficiary.write` |
+
+Consulte a referência completa na página [API](/api-redoc/) (tag **anticipation**).
+
+## Erros
+
+| Status | Significado |
+| --- | --- |
+| `400` | Corpo/parâmetros inválidos. Formato: `{ "error": "mensagem" }` |
+| `401` | `app_id` inválido ou IP não autorizado. Formato: `{ "data": null, "errors": [{ "message": "Invalid appID" }] }` |
+| `403` | Escopo ausente ou Antecipação não habilitada para a empresa. Formato: `{ "error": "mensagem" }` |
+| `404` | Beneficiário não encontrado (nas rotas por `taxID`). |
+| `409` | Beneficiário já existe para o CPF/CNPJ (no cadastro). |

--- a/docs/anticipation/how-to-activate-and-deactivate-a-beneficiary-using-api.mdx
+++ b/docs/anticipation/how-to-activate-and-deactivate-a-beneficiary-using-api.mdx
@@ -1,0 +1,84 @@
+---
+id: how-to-activate-and-deactivate-a-beneficiary-using-api
+title: Como ativar ou desativar um beneficiário via API?
+sidebar_label: Ativar / desativar beneficiário
+sidebar_position: 4
+tags:
+  - api
+  - anticipation
+  - antecipacao
+  - beneficiary
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Você pode ativar ou desativar um beneficiário pelo seu `taxID` (a chave de
+pagamento, CPF ou CNPJ). Um beneficiário **desativado** não consegue solicitar
+novas antecipações nem acessar o aplicativo.
+
+Ambos os _endpoints_ exigem o escopo `anticipation.beneficiary.write`.
+
+| Ação | Endpoint |
+| --- | --- |
+| Ativar | `POST /api/v1/anticipation/beneficiary/{taxID}/activate` |
+| Desativar | `POST /api/v1/anticipation/beneficiary/{taxID}/deactivate` |
+
+O `{taxID}` pode ir com ou sem máscara — apenas os dígitos são considerados. Se
+não existir beneficiário com aquele `taxID` na empresa, a resposta é `404`.
+
+### Exemplos em código
+
+<Tabs>
+  <TabItem value="shell-curl" label="Shell + cURL" default>
+
+```sh
+# Desativar
+curl 'https://api.woovi.com/api/v1/anticipation/beneficiary/12345678909/deactivate' -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: {SEU_APP_ID}"
+
+# Ativar
+curl 'https://api.woovi.com/api/v1/anticipation/beneficiary/12345678909/activate' -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: {SEU_APP_ID}"
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript + Fetch" default>
+
+```js
+const taxID = '12345678909';
+
+fetch(`https://api.woovi.com/api/v1/anticipation/beneficiary/${taxID}/deactivate`, {
+  method: 'POST',
+  headers: {
+    Authorization: '{SEU_APP_ID}',
+    'Content-Type': 'application/json',
+  },
+}).then((res) => res.json());
+```
+
+  </TabItem>
+</Tabs>
+
+### Exemplo de resposta
+
+```json
+{
+  "beneficiary": {
+    "name": "João da Silva",
+    "taxID": {
+      "taxID": "12345678909",
+      "type": "BR:CPF"
+    },
+    "isActive": false,
+    "availableAmount": 500000,
+    "maxAdvanceableAmount": 350000,
+    "notifyEmail": "joao@empresa.com",
+    "notifyPhone": "+5511999999999",
+    "verified": true,
+    "createdAt": "2026-07-15T12:00:00.000Z"
+  }
+}
+```

--- a/docs/anticipation/how-to-register-a-beneficiary-using-api.mdx
+++ b/docs/anticipation/how-to-register-a-beneficiary-using-api.mdx
@@ -1,0 +1,116 @@
+---
+id: how-to-register-a-beneficiary-using-api
+title: Como cadastrar um beneficiário via API?
+sidebar_label: Cadastrar beneficiário
+sidebar_position: 2
+tags:
+  - api
+  - anticipation
+  - antecipacao
+  - beneficiary
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Para cadastrar um beneficiário na Antecipação você utiliza o _endpoint_
+`POST /api/v1/anticipation/beneficiary`.
+
+O beneficiário fica vinculado à empresa identificada pelo `app_id` do cabeçalho
+`Authorization`. Requer o escopo `anticipation.beneficiary.write`.
+
+## Campos do corpo
+
+| Campo | Tipo | Obrigatório | Descrição |
+| --- | --- | --- | --- |
+| `name` | string | Sim | Nome do beneficiário (2 a 120 caracteres). |
+| `taxID` | string | Sim | Chave de pagamento (CPF ou CNPJ), com ou sem máscara. |
+| `cpf` | string | Condicional | CPF da pessoa. Obrigatório quando `taxID` é um CNPJ. |
+| `notifyEmail` | string | Não | E-mail para notificações. |
+| `notifyPhone` | string | Não | Telefone para notificações. |
+| `availableAmount` | integer | Não | Saldo disponível, em centavos. |
+| `maxAdvanceableAmount` | integer | Não | Limite antecipável, em centavos. |
+| `autoApprove` | boolean | Não | Sobrescreve a aprovação automática da empresa para este beneficiário. |
+| `feeDestinationAccountId` | string | Não | Conta de destino da taxa (sobrescreve a configuração da empresa). |
+| `paymentDaysOverride` | integer[] | Não | Dias de pagamento (1–31) específicos deste beneficiário. |
+| `frequencyOverride` | object | Não | `{ maxAdvances, periodDays }` — janela de frequência específica. |
+| `correlationID` | string | Não | Identificador seu, devolvido na resposta para reconciliação. |
+
+## Idempotência
+
+O `taxID` é único por empresa. Se você reenviar um `taxID` já cadastrado, a API
+retorna `409`. Para tornar a chamada idempotente, envie a _query string_
+`?return_existing=true`: nesse caso o beneficiário existente é retornado com
+`200` em vez de erro.
+
+### Exemplos em código
+
+<Tabs>
+  <TabItem value="shell-curl" label="Shell + cURL" default>
+
+```sh
+curl 'https://api.woovi.com/api/v1/anticipation/beneficiary?return_existing=true' -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: {SEU_APP_ID}" \
+    -d '{
+      "name": "João da Silva",
+      "taxID": "12345678909",
+      "notifyEmail": "joao@empresa.com",
+      "notifyPhone": "+5511999999999",
+      "availableAmount": 500000,
+      "maxAdvanceableAmount": 350000,
+      "correlationID": "erp-benef-42"
+    }'
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript + Fetch" default>
+
+```js
+fetch('https://api.woovi.com/api/v1/anticipation/beneficiary?return_existing=true', {
+  method: 'POST',
+  headers: {
+    Authorization: '{SEU_APP_ID}',
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    name: 'João da Silva',
+    taxID: '12345678909',
+    notifyEmail: 'joao@empresa.com',
+    notifyPhone: '+5511999999999',
+    availableAmount: 500000,
+    maxAdvanceableAmount: 350000,
+    correlationID: 'erp-benef-42',
+  }),
+}).then((res) => res.json());
+```
+
+  </TabItem>
+</Tabs>
+
+### Exemplo de resposta
+
+```json
+{
+  "beneficiary": {
+    "name": "João da Silva",
+    "taxID": {
+      "taxID": "12345678909",
+      "type": "BR:CPF"
+    },
+    "isActive": true,
+    "availableAmount": 500000,
+    "maxAdvanceableAmount": 350000,
+    "notifyEmail": "joao@empresa.com",
+    "notifyPhone": "+5511999999999",
+    "verified": false,
+    "createdAt": "2026-07-15T12:00:00.000Z"
+  },
+  "correlationID": "erp-benef-42"
+}
+```
+
+:::note
+`type` é `BR:CPF` ou `BR:CNPJ`. `verified` indica se o beneficiário já concluiu a
+verificação de identidade (pix-auth) no aplicativo.
+:::

--- a/docs/anticipation/how-to-sync-beneficiary-balances-using-api.mdx
+++ b/docs/anticipation/how-to-sync-beneficiary-balances-using-api.mdx
@@ -1,0 +1,103 @@
+---
+id: how-to-sync-beneficiary-balances-using-api
+title: Como sincronizar saldos de beneficiários em lote via API?
+sidebar_label: Sincronizar saldos (lote)
+sidebar_position: 3
+tags:
+  - api
+  - anticipation
+  - antecipacao
+  - balance
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Para atualizar os saldos antecipáveis de vários beneficiários de uma vez — o caso
+típico é a carga noturna vinda da folha de pagamento — use o _endpoint_
+`POST /api/v1/anticipation/balance/batch`.
+
+Requer o escopo `anticipation.balance.write`.
+
+## Como funciona
+
+- O valor é um **set absoluto**: `availableAmount` e `maxAdvanceableAmount`
+  passam a valer exatamente o que você enviar (não é incremento). Por isso a
+  operação é naturalmente idempotente — reenviar o mesmo lote é seguro.
+- Cada lote aceita no **máximo 1000 itens**.
+- Falhas parciais **não** abortam o lote: a resposta traz um relatório por item
+  para você reconciliar no ERP.
+
+## Campos do corpo
+
+| Campo | Tipo | Obrigatório | Descrição |
+| --- | --- | --- | --- |
+| `items` | array | Sim | Lista de itens (1 a 1000). |
+| `items[].taxID` | string | Sim | Chave de pagamento (CPF ou CNPJ) do beneficiário. |
+| `items[].availableAmount` | integer | Sim | Saldo disponível, em centavos (≥ 0). |
+| `items[].maxAdvanceableAmount` | integer | Sim | Limite antecipável, em centavos (≥ 0, ≤ `availableAmount`). |
+
+:::caution
+Regras de validação por item: `taxID` obrigatório, valores inteiros não
+negativos e `maxAdvanceableAmount` não pode exceder `availableAmount`. Itens que
+violem qualquer regra — ou cujo beneficiário não exista na empresa — retornam
+`ok: false` com o motivo, sem afetar os demais.
+:::
+
+### Exemplos em código
+
+<Tabs>
+  <TabItem value="shell-curl" label="Shell + cURL" default>
+
+```sh
+curl 'https://api.woovi.com/api/v1/anticipation/balance/batch' -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: {SEU_APP_ID}" \
+    -d '{
+      "items": [
+        { "taxID": "12345678909", "availableAmount": 500000, "maxAdvanceableAmount": 350000 },
+        { "taxID": "98765432100", "availableAmount": 120000, "maxAdvanceableAmount": 120000 }
+      ]
+    }'
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript + Fetch" default>
+
+```js
+fetch('https://api.woovi.com/api/v1/anticipation/balance/batch', {
+  method: 'POST',
+  headers: {
+    Authorization: '{SEU_APP_ID}',
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    items: [
+      { taxID: '12345678909', availableAmount: 500000, maxAdvanceableAmount: 350000 },
+      { taxID: '98765432100', availableAmount: 120000, maxAdvanceableAmount: 120000 },
+    ],
+  }),
+}).then((res) => res.json());
+```
+
+  </TabItem>
+</Tabs>
+
+### Exemplo de resposta
+
+```json
+{
+  "processed": 2,
+  "succeeded": 1,
+  "failed": 1,
+  "results": [
+    { "taxID": "12345678909", "ok": true },
+    { "taxID": "98765432100", "ok": false, "error": "beneficiary not found" }
+  ]
+}
+```
+
+O beneficiário precisa já estar cadastrado (veja
+[Cadastrar beneficiário](./how-to-register-a-beneficiary-using-api.mdx)); itens
+apontando para um `taxID` inexistente na empresa voltam com
+`error: "beneficiary not found"`.

--- a/src/swaggers/woovi.json
+++ b/src/swaggers/woovi.json
@@ -21,6 +21,530 @@
     }
   ],
   "paths": {
+    "/api/v1/anticipation/beneficiary": {
+      "post": {
+        "tags": [
+          "anticipation"
+        ],
+        "summary": "Register a beneficiary",
+        "description": "Registers a beneficiary bound to the company resolved from the app_id. Idempotent on the payout key: send `?return_existing=true` to get the existing beneficiary (200) instead of a 409.",
+        "x-required-scope": "anticipation.beneficiary.write",
+        "security": [
+          {
+            "AppID": [
+              "anticipation.beneficiary.write"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "return_existing",
+            "in": "query",
+            "required": false,
+            "description": "When `true`, an already-existing beneficiary is returned with 200 instead of a 409.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnticipationBeneficiaryCreatePayload"
+              },
+              "examples": {
+                "beneficiary": {
+                  "value": {
+                    "name": "João da Silva",
+                    "taxID": "12345678909",
+                    "notifyEmail": "joao@empresa.com",
+                    "notifyPhone": "+5511999999999",
+                    "availableAmount": 500000,
+                    "maxAdvanceableAmount": 350000,
+                    "correlationID": "erp-benef-42"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Beneficiário cadastrado (ou existente, com return_existing)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "beneficiary": {
+                      "$ref": "#/components/schemas/AnticipationBeneficiary"
+                    },
+                    "correlationID": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Corpo inválido",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "app_id inválido ou IP não autorizado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "message": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "example": {
+                    "data": null,
+                    "errors": [
+                      {
+                        "message": "Invalid appID"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Escopo ausente ou Antecipação não habilitada",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Beneficiário já existe para o CPF/CNPJ",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/anticipation/balance/batch": {
+      "post": {
+        "tags": [
+          "anticipation"
+        ],
+        "summary": "Bulk-sync beneficiary balances",
+        "description": "Absolute set of availableAmount/maxAdvanceableAmount for up to 1000 beneficiaries in one call (nightly payroll sync). Returns a per-item report so partial failures can be reconciled.",
+        "x-required-scope": "anticipation.balance.write",
+        "security": [
+          {
+            "AppID": [
+              "anticipation.balance.write"
+            ]
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnticipationBalanceBatchPayload"
+              },
+              "examples": {
+                "batch": {
+                  "value": {
+                    "items": [
+                      {
+                        "taxID": "12345678909",
+                        "availableAmount": 500000,
+                        "maxAdvanceableAmount": 350000
+                      },
+                      {
+                        "taxID": "98765432100",
+                        "availableAmount": 120000,
+                        "maxAdvanceableAmount": 120000
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Relatório de processamento por item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnticipationBalanceBatchResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "items ausente, vazio ou acima de 1000",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "app_id inválido ou IP não autorizado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "message": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "example": {
+                    "data": null,
+                    "errors": [
+                      {
+                        "message": "Invalid appID"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Escopo ausente ou Antecipação não habilitada",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/anticipation/beneficiary/{taxID}/activate": {
+      "post": {
+        "tags": [
+          "anticipation"
+        ],
+        "summary": "Activate a beneficiary",
+        "description": "Reactivates a beneficiary previously deactivated.",
+        "x-required-scope": "anticipation.beneficiary.write",
+        "security": [
+          {
+            "AppID": [
+              "anticipation.beneficiary.write"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "taxID",
+            "in": "path",
+            "required": true,
+            "description": "Chave de pagamento (CPF ou CNPJ), com ou sem máscara.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Beneficiário atualizado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "beneficiary": {
+                      "$ref": "#/components/schemas/AnticipationBeneficiary"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "taxID inválido",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "app_id inválido ou IP não autorizado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "message": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "example": {
+                    "data": null,
+                    "errors": [
+                      {
+                        "message": "Invalid appID"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Escopo ausente ou Antecipação não habilitada",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Beneficiário não encontrado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/anticipation/beneficiary/{taxID}/deactivate": {
+      "post": {
+        "tags": [
+          "anticipation"
+        ],
+        "summary": "Deactivate a beneficiary",
+        "description": "Deactivates a beneficiary: blocks new anticipations and app login.",
+        "x-required-scope": "anticipation.beneficiary.write",
+        "security": [
+          {
+            "AppID": [
+              "anticipation.beneficiary.write"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "taxID",
+            "in": "path",
+            "required": true,
+            "description": "Chave de pagamento (CPF ou CNPJ), com ou sem máscara.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Beneficiário atualizado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "beneficiary": {
+                      "$ref": "#/components/schemas/AnticipationBeneficiary"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "taxID inválido",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "app_id inválido ou IP não autorizado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "message": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "example": {
+                    "data": null,
+                    "errors": [
+                      {
+                        "message": "Invalid appID"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Escopo ausente ou Antecipação não habilitada",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Beneficiário não encontrado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/account/{accountId}": {
       "delete": {
         "tags": [
@@ -14976,6 +15500,204 @@
   },
   "components": {
     "schemas": {
+    "AnticipationBeneficiaryCreatePayload": {
+      "type": "object",
+      "required": [
+        "name",
+        "taxID"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120,
+          "description": "Nome do beneficiário."
+        },
+        "taxID": {
+          "type": "string",
+          "description": "Chave de pagamento (CPF ou CNPJ), com ou sem máscara."
+        },
+        "cpf": {
+          "type": "string",
+          "nullable": true,
+          "description": "CPF da pessoa. Obrigatório quando taxID é um CNPJ."
+        },
+        "notifyEmail": {
+          "type": "string",
+          "format": "email",
+          "nullable": true
+        },
+        "notifyPhone": {
+          "type": "string",
+          "nullable": true
+        },
+        "availableAmount": {
+          "type": "integer",
+          "minimum": 0,
+          "nullable": true,
+          "description": "Saldo disponível, em centavos."
+        },
+        "maxAdvanceableAmount": {
+          "type": "integer",
+          "minimum": 0,
+          "nullable": true,
+          "description": "Limite antecipável, em centavos."
+        },
+        "autoApprove": {
+          "type": "boolean",
+          "nullable": true
+        },
+        "feeDestinationAccountId": {
+          "type": "string",
+          "nullable": true
+        },
+        "paymentDaysOverride": {
+          "type": "array",
+          "nullable": true,
+          "items": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 31
+          }
+        },
+        "frequencyOverride": {
+          "type": "object",
+          "nullable": true,
+          "properties": {
+            "maxAdvances": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "periodDays": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "correlationID": {
+          "type": "string",
+          "nullable": true,
+          "description": "Identificador do chamador, devolvido na resposta."
+        }
+      }
+    },
+    "AnticipationBeneficiary": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "taxID": {
+          "type": "object",
+          "properties": {
+            "taxID": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "BR:CPF",
+                "BR:CNPJ"
+              ]
+            }
+          }
+        },
+        "isActive": {
+          "type": "boolean"
+        },
+        "availableAmount": {
+          "type": "integer",
+          "nullable": true
+        },
+        "maxAdvanceableAmount": {
+          "type": "integer"
+        },
+        "notifyEmail": {
+          "type": "string",
+          "nullable": true
+        },
+        "notifyPhone": {
+          "type": "string",
+          "nullable": true
+        },
+        "verified": {
+          "type": "boolean",
+          "description": "Se o beneficiário concluiu a verificação de identidade (pix-auth)."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "nullable": true
+        }
+      }
+    },
+    "AnticipationBalanceBatchPayload": {
+      "type": "object",
+      "required": [
+        "items"
+      ],
+      "properties": {
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1000,
+          "items": {
+            "type": "object",
+            "required": [
+              "taxID",
+              "availableAmount",
+              "maxAdvanceableAmount"
+            ],
+            "properties": {
+              "taxID": {
+                "type": "string"
+              },
+              "availableAmount": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Saldo disponível, em centavos."
+              },
+              "maxAdvanceableAmount": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Limite antecipável, em centavos. Não pode exceder availableAmount."
+              }
+            }
+          }
+        }
+      }
+    },
+    "AnticipationBalanceBatchResult": {
+      "type": "object",
+      "properties": {
+        "processed": {
+          "type": "integer"
+        },
+        "succeeded": {
+          "type": "integer"
+        },
+        "failed": {
+          "type": "integer"
+        },
+        "results": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "taxID": {
+                "type": "string"
+              },
+              "ok": {
+                "type": "boolean"
+              },
+              "error": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
       "PayloadAccount": {
         "type": "object",
         "properties": {
@@ -18750,7 +19472,9 @@
               "WEBHOOK_EVENTS_GET_LIST": "Get a list of webhook events",
               "WEBHOOK_POST": "Create a new Webhook",
               "WEBHOOK_DELETE": "Delete a Webhook",
-              "WEBHOOK_IPS_GET": "Get a list of webhook IPs"
+              "WEBHOOK_IPS_GET": "Get a list of webhook IPs",
+          "anticipation.beneficiary.write": "Register, activate and deactivate anticipation beneficiaries",
+          "anticipation.balance.write": "Bulk-sync anticipation beneficiary balances"
             }
           }
         }
@@ -18865,6 +19589,10 @@
     {
       "name": "webhook",
       "description": "Endpoint to manage Webhooks\n"
+    },
+    {
+      "name": "anticipation",
+      "description": "Endpoints to integrate the Anticipation product: register beneficiaries and sync their advanceable balances from an ERP/payroll.\n"
     }
   ]
 }


### PR DESCRIPTION
## O que

Documenta a **API REST de Antecipação** (`woovi-anticipation-backend`) no site de developers, em duas superfícies:

**Guias (nova seção "Antecipação"):**
- `anticipation-api-overview` — autenticação por `app_id`, escopos, URL base, convenções (valores em centavos, `taxID` CPF/CNPJ, datas ISO) e tabela de erros.
- Como cadastrar um beneficiário (`POST /beneficiary`, com idempotência via `?return_existing=true`).
- Como sincronizar saldos em lote (`POST /balance/batch`, set absoluto, até 1000 itens, relatório por item).
- Como ativar/desativar um beneficiário.

**OpenAPI (`src/swaggers/woovi.json`) — renderizado no `/api`:**
- Nova tag `anticipation` com os 4 endpoints, request/response schemas e exemplos.
- 2 escopos novos no securityScheme AppID: `anticipation.beneficiary.write`, `anticipation.balance.write`.
- Os endpoints herdam os `servers` globais (`api.woovi.com` / `api.woovi-sandbox.com`).

Contratos extraídos direto da implementação (`apiRouter.ts`, `apiAuthMiddleware.ts`, `serializeBeneficiary.ts`, `createBeneficiary.ts`).

## Notas de revisão

- A edição do `woovi.json` foi **cirúrgica** (inserção por âncoras) para não reformatar o arquivo: diff de +729/-1, conteúdo existente byte-idêntico. Validado com `JSON.parse` + parse YAML estrito do Redocly.
- `pnpm build` gera as 4 páginas + a tag em pt-BR e en, sem warnings relacionados a antecipação.