### PR TITLE
fix: use api.woovi.com in subscription boleto create API examples

### DIFF
--- a/docs/subscription-recurrence/subscription-with-boleto-create-api.mdx
+++ b/docs/subscription-recurrence/subscription-with-boleto-create-api.mdx
@@ -131,7 +131,7 @@ quitada", não como saldo disponível.
 
 ```sh
  curl --request POST \
-     --url https://api.openpix.com.br/api/v1/subscriptions \
+     --url https://api.woovi.com/api/v1/subscriptions \
      --header 'Authorization: AUTHORIZATION' \
      --header 'content-type: application/json' \
      --data '{"value": 15000,"type":"RECURRENT","chargeType":"BOLETO","customer": {"name":"Dan","taxID":"31324227036","email":"email0@example.com","phone":"5511999999999", "address":{"zipcode":"30421322","street":"Street","number":"100","neighborhood":"Neighborhood","city":"Belo Horizonte","state":"MG","complement":"APTO","country":"BR"}}}'
@@ -141,7 +141,7 @@ quitada", não como saldo disponível.
   <TabItem value="javascript" label="JavaScript + Fetch" default>
 
 ```js
-fetch('https://api.openpix.com.br/api/v1/subscriptions', {
+fetch('https://api.woovi.com/api/v1/subscriptions', {
   method: 'POST',
   body: JSON.stringify({
     value: 15000,


### PR DESCRIPTION
The [Subscription with boleto](https://developers.woovi.com/docs/subscription-recurrence/subscription-with-boleto-create-api) doc page pointed the code examples at the wrong API host `api.openpix.com.br`. The correct host is `api.woovi.com`.

This PR fixes both the Shell + cURL and JavaScript + Fetch examples on that page. A follow-up PR will sweep the remaining incorrect openpix references across the rest of the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)