### PR TITLE
fix: use correct woovi hosts in API and docs references

### DIFF
--- a/docs/apis/api-versioning-deprecation.md
+++ b/docs/apis/api-versioning-deprecation.md
@@ -12,7 +12,7 @@ conduzimos a depreciação de recursos com prazo de _sunset_ e comunicação pr�
 
 ## Versionamento
 
-- A API é versionada no **caminho da URL**: `https://api.openpix.com.br/api/v1/...`
+- A API é versionada no **caminho da URL**: `https://api.woovi.com/api/v1/...`
   (produção) e `https://api.woovi-sandbox.com/api/v1/...` (sandbox).
 - Seguimos **[SemVer](https://semver.org/lang/pt-BR/)**: a versão é composta por
   `major.minor.patch`. **Mudanças compatíveis não geram nova versão _major_.**

--- a/docs/charge/how-to-create-charge-with-split-to-subaccount-using-api.mdx
+++ b/docs/charge/how-to-create-charge-with-split-to-subaccount-using-api.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 Para criar uma cobrança Pix com split para sub conta, você utiliza o _endpoint_ `/api/v1/charge` da API.
 
-Você pode acessar [aqui](https://developers.openpix.com.br/api#tag/charge/paths/~1api~1v1~1charge/post)
+Você pode acessar [aqui](https://developers.woovi.com/api#tag/charge/paths/~1api~1v1~1charge/post)
 a documentação referente a esse _endpoint_.
 
 Os campos obrigatórios para criar uma cobrança Pix com Split são os seguintes:
@@ -62,7 +62,7 @@ Após efetuar a requisição, se tudo ocorreu bem, o _status code_ da requisiç�
   <TabItem value="shell-curl" label="Shell + cURL" default>
 
 ```sh
-  curl 'https://api.openpix.com.br/api/v1/charge' -X POST \
+  curl 'https://api.woovi.com/api/v1/charge' -X POST \
       -H "Accept: application/json" \
       -H "Content-Type: application/json" \
       -H "user-agent: node-fetch" \
@@ -73,7 +73,7 @@ Após efetuar a requisição, se tudo ocorreu bem, o _status code_ da requisiç�
   <TabItem value="javascript" label="JavaScript + Fetch" default>
 
 ```js
-fetch('https://api.openpix.com.br/api/v1/charge', {
+fetch('https://api.woovi.com/api/v1/charge', {
   method: 'POST',
   body: JSON.stringify({
     value: 100,

--- a/docs/flows/fraud-statistic.md
+++ b/docs/flows/fraud-statistic.md
@@ -143,7 +143,7 @@ A API utiliza os seguintes indicadores de período:
 
 ### cURL
 ```bash
-curl -X GET "https://api.openpix.com.br/api/v1/pix-keys/12345678901/fraud-validation" \
+curl -X GET "https://api.woovi.com/api/v1/pix-keys/12345678901/fraud-validation" \
   -H "Authorization: SEU_APP_ID_AQUI"
 ```
 

--- a/docs/flows/person-statistic.md
+++ b/docs/flows/person-statistic.md
@@ -89,7 +89,7 @@ A API utiliza os seguintes indicadores de período:
 
 ### cURL
 ```bash
-curl -X GET "https://api.openpix.com.br/api/v1/fraud-validation/taxId/12345678901" \
+curl -X GET "https://api.woovi.com/api/v1/fraud-validation/taxId/12345678901" \
   -H "Authorization: SEU_APP_ID_AQUI"
 ```
 

--- a/docs/subscription-recurrence/subscription-with-interests-and-fines-create-api.mdx
+++ b/docs/subscription-recurrence/subscription-with-interests-and-fines-create-api.mdx
@@ -96,7 +96,7 @@ Retornarmeros a seguinte resposta de exemplo:
 
 ```sh
  curl --request POST \
-     --url https://api.openpix.com.br/api/v1/subscriptions \
+     --url https://api.woovi.com/api/v1/subscriptions \
      --header 'Authorization: AUTHORIZATION' \
      --header 'content-type: application/json' \
      --data '{"value": 100,"customer": {"name":"Dan","taxID":"31324227036","email":"email0@example.com","phone":"5511999999999", "address":{"zipcode":"30421322","street":"Street","number":"100","neighborhood":"Neighborhood","city":"Belo Horizonte","state":"MG","complement":"APTO","country":"BR"}},"chargeType":"OVERDUE"}'
@@ -106,7 +106,7 @@ Retornarmeros a seguinte resposta de exemplo:
   <TabItem value="javascript" label="JavaScript + Fetch" default>
 
 ```js
-fetch('https://api.openpix.com.br/api/v1/subscriptions', {
+fetch('https://api.woovi.com/api/v1/subscriptions', {
   method: 'POST',
   body: JSON.stringify({
     value: 100,

--- a/docs/webhook/examples/refund-received-rejected.mdx
+++ b/docs/webhook/examples/refund-received-rejected.mdx
@@ -16,7 +16,7 @@ Os webhooks do tipo `PIX_TRANSACTION_REFUND_RECEIVED_REJECTED` enviam objetos co
 - `originalTransaction`: Detalhes da transação original que está sendo reembolsada
 - `company`: Empresa a que a Transação pertence
 - `account`: Detalhes da conta que a Transação pertence
-- `error`: Detalhes do motivo pela qual o Estorno foi rejeitado - [Códigos de erro de pagamento](https://developers.openpix.com.br/en/docs/flows/error-codes-payment)
+- `error`: Detalhes do motivo pela qual o Estorno foi rejeitado - [Códigos de erro de pagamento](/docs/flows/error-codes-payment)
 
 ## Exemplo
 

--- a/docs/webhook/examples/refund-sent-rejected.mdx
+++ b/docs/webhook/examples/refund-sent-rejected.mdx
@@ -16,7 +16,7 @@ Os webhooks do tipo `PIX_TRANSACTION_REFUND_SENT_REJECTED` enviam objetos com os
 - `originalTransaction`: Detalhes da transação original que está sendo reembolsada
 - `company`: Empresa a que a Transação pertence
 - `account`: Detalhes da conta que a Transação pertence
-- `error`: Detalhes do motivo pela qual o Estorno foi rejeitado - [Códigos de erro de pagamento](https://developers.openpix.com.br/en/docs/flows/error-codes-payment)
+- `error`: Detalhes do motivo pela qual o Estorno foi rejeitado - [Códigos de erro de pagamento](/docs/flows/error-codes-payment)
 
 ## Exemplo
 


### PR DESCRIPTION
Follow-up to the subscription-with-boleto fix (#721), sweeping the remaining incorrect `openpix.com.br` references across the docs.

## API host
Replaced the wrong production API host `api.openpix.com.br` with the correct `api.woovi.com` in the examples that users actually call:

- `apis/api-versioning-deprecation.md` (now consistent with the `api.woovi-sandbox.com` line right below it)
- `flows/fraud-statistic.md` and `flows/person-statistic.md`
- `charge/how-to-create-charge-with-split-to-subaccount-using-api.mdx` (cURL + fetch)
- `subscription-recurrence/subscription-with-interests-and-fines-create-api.mdx` (cURL + fetch)

## Docs links
- `charge/how-to-create-charge-with-split-to-subaccount-using-api.mdx`: `developers.openpix.com.br/api#...` → `developers.woovi.com/api#...`, matching the convention used elsewhere in the docs.
- `webhook/examples/refund-sent-rejected.mdx` and `refund-received-rejected.mdx`: the payment error-codes link now uses the internal relative link `/docs/flows/error-codes-payment`, the way the rest of the docs reference that page.

## Deliberately left untouched
These embed `api.openpix.com.br` inside example payloads where changing the host would break the example itself, and they are not the API base URL a user calls:

- `webhook/seguranca/webhook-signature-validation.mdx`: the `brCode` lives inside a payload validated against a hardcoded RSA signature — editing the bytes would make the example fail verification.
- `payment/payment-how-to-use-api-to-create.mdx`: the host is embedded in an EMV BR Code string with a length prefix and CRC16 — editing it would produce an invalid QR code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)