### PR TITLE
fix: replace OpenPix brand mentions with Woovi in docs prose

### DIFF
--- a/docs/anticipation/anticipation-api-overview.mdx
+++ b/docs/anticipation/anticipation-api-overview.mdx
@@ -14,7 +14,7 @@ A **API de Antecipação** permite que um sistema externo (ERP, folha de pagamen
 ou backoffice) cadastre beneficiários e sincronize os saldos antecipáveis de uma
 empresa que utiliza o produto de Antecipação da Woovi.
 
-É uma API REST no estilo OpenPix: autenticação por `app_id` no cabeçalho
+É uma API REST no estilo Woovi: autenticação por `app_id` no cabeçalho
 `Authorization`, corpo em JSON, valores monetários **em centavos** e escopos por
 funcionalidade.
 

--- a/docs/apis/api-versioning-deprecation.md
+++ b/docs/apis/api-versioning-deprecation.md
@@ -6,7 +6,7 @@ tags:
   - api
 ---
 
-A Woovi/OpenPix se compromete a **não quebrar silenciosamente** integrações em produção.
+A Woovi se compromete a **não quebrar silenciosamente** integrações em produção.
 Esta página descreve como versionamos a API, o que garantimos de compatibilidade, e como
 conduzimos a depreciação de recursos com prazo de _sunset_ e comunicação prévia.
 

--- a/docs/charge/how-to-create-charge-with-split-to-subaccount-using-api.mdx
+++ b/docs/charge/how-to-create-charge-with-split-to-subaccount-using-api.mdx
@@ -31,7 +31,7 @@ O body da sua requisição será semelhante a este exemplo:
   "correlationID": "c782e0ac-833d-4a89-9e73-9b60b2b41d3a",
   "splits": [
     {
-      "pixKey": "destinatario@openpix.com.br",
+      "pixKey": "destinatario@example.com",
       "value": 15,
       "splitType": "SPLIT_SUB_ACCOUNT"
     }
@@ -48,7 +48,7 @@ Após efetuar a requisição, se tudo ocorreu bem, o _status code_ da requisiç�
   "charge": {
     ...Charge Payload
     "splits": [
-      { "pixKey": "destinatario@openpix.com.br", "value": 15, splitType: "SPLIT_SUB_ACCOUNT" },
+      { "pixKey": "destinatario@example.com", "value": 15, splitType: "SPLIT_SUB_ACCOUNT" },
     ]
   },
   "correlationID": "c782e0ac-833d-4a89-9e73-9b60b2b41d3a",
@@ -66,7 +66,7 @@ Após efetuar a requisição, se tudo ocorreu bem, o _status code_ da requisiç�
       -H "Accept: application/json" \
       -H "Content-Type: application/json" \
       -H "user-agent: node-fetch" \
-      --data-binary '{"correlationID":"c782e0ac-833d-4a89-9e73-9b60b2b41d3a","value":100, "splits": [{ "pixKey": "destinatario@openpix.com.br", "value": 15, splitType:"SPLIT_SUB_ACCOUNT"  }]}'
+      --data-binary '{"correlationID":"c782e0ac-833d-4a89-9e73-9b60b2b41d3a","value":100, "splits": [{ "pixKey": "destinatario@example.com", "value": 15, splitType:"SPLIT_SUB_ACCOUNT"  }]}'
 ```
 
   </TabItem>
@@ -80,7 +80,7 @@ fetch('https://api.woovi.com/api/v1/charge', {
     correlationID: 'c782e0ac-833d-4a89-9e73-9b60b2b41d3a',
     splits: [
       {
-        pixKey: 'destinatario@openpix.com.br',
+        pixKey: 'destinatario@example.com',
         value: 15,
         splitType: 'SPLIT_SUB_ACCOUNT',
       },

--- a/docs/ecommerce/woocommerce/woocommerce-plugin.mdx
+++ b/docs/ecommerce/woocommerce/woocommerce-plugin.mdx
@@ -93,7 +93,7 @@ Valide que o status do Pedido mudou após o pagamento
 
 ## 4. Como configurar a expiração do pedido Woocommerce
 
-A cobrança da Openpix tem um valor de expiração padrão que equivale a 1 dia, já a configuração de expiração padrão do Woocommerce é de 60 minutos
+A cobrança da Woovi tem um valor de expiração padrão que equivale a 1 dia, já a configuração de expiração padrão do Woocommerce é de 60 minutos
 
 Para saber mais sobre Como configurar o tempo de expiração da Woovi Charge [Clique aqui](/docs/flows/flow-edit-default-expiration).
 
@@ -109,17 +109,17 @@ Por último, alterar o valor do Hold stock para 1440 minutos equivalente a 1 dia
 
 ## 5. Como selecionar qual deverá ser o status quando um novo pedido for gerado
 
-Por padrão quando a cobrança da Openpix é criada, o status do pedido é alterado para `Pending payment`, porém é possível configurar para qualquer status que você queira.
+Por padrão quando a cobrança da Woovi é criada, o status do pedido é alterado para `Pending payment`, porém é possível configurar para qualquer status que você queira.
 
 ![Woocommerce Status do Pedido Criado](/img/ecommerce/woocommerce-status-when-create-default.png)
 
-Basta clicar e selecionar qual status você quer que seja colocado no pedido quando a cobrança da Openpix for criada.
+Basta clicar e selecionar qual status você quer que seja colocado no pedido quando a cobrança da Woovi for criada.
 
 Após esta alteração os novos pedidos quando forem criados irão receber o valor desse campo em seu status.
 
 ## 6. Como selecionar qual deverá ser o status quando um pedido for pago
 
-Por padrão quando a cobrança da Openpix é paga, o status do pedido é alterado para `Processing`, porém é possível configurar para qualquer status que você queira.
+Por padrão quando a cobrança da Woovi é paga, o status do pedido é alterado para `Processing`, porém é possível configurar para qualquer status que você queira.
 
 ![Woocommerce Status do Pedido Pago](/img/ecommerce/woocommerce-status-when-paid-default.png)
 

--- a/docs/flows/flow-edit-default-expiration.mdx
+++ b/docs/flows/flow-edit-default-expiration.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-A cobrança da Openpix tem um valor de expiração padrão equivalente a 1 mês, mas você pode alterar esse tempo de expiração ao seu caso de uso
+A cobrança da Woovi tem um valor de expiração padrão equivalente a 1 mês, mas você pode alterar esse tempo de expiração ao seu caso de uso
 
 Procure no menu Admin por `Settings` > `Pix`
 

--- a/docs/flows/webhook/flow-creating-webhook.mdx
+++ b/docs/flows/webhook/flow-creating-webhook.mdx
@@ -8,7 +8,7 @@ tags:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Pela Openpix é possível criar webhooks para interceptar quando um pix for realizado. Hoje, há duas maneiras de realizar a criação do mesmo: via plataforma ou API.
+Pela Woovi é possível criar webhooks para interceptar quando um pix for realizado. Hoje, há duas maneiras de realizar a criação do mesmo: via plataforma ou API.
 
 Abaixo temos exemplos de como criá-los:
 

--- a/docs/integrations/integrating-pix-with-whatsapp.md
+++ b/docs/integrations/integrating-pix-with-whatsapp.md
@@ -134,7 +134,7 @@ Parabéns! Você configurou o BotConversa com a Woovi!
 Caso queira inserir dados e informações da resposta do webhook, assista o tutorial a seguir: 
 [Webhook disponibilizado para BotConversa ser acionado por outros sistemas sem intermediários](https://us06web.zoom.us/rec/play/3Xj5dcuBRDULOApuSKMPgwJa4eCmjzHkyBwRXvgR4OHDKq2FZwyiE-YZ3Rweygr4qn8kOOo74Zcyffc7.6-YttRdjMSm1VdNm?startTime=1664975296000&_x_zm_rtaid=PZVKWRNiRkeAYNHwBjDPnA.1673398847814.5bd6a02e3760d79e2115e1c2c8286b28&_x_zm_rhtaid=589).
 
-## 6. Materiais complementares da comunidade Woovi/OpenPix
+## 6. Materiais complementares da comunidade Woovi
 
 - [Como Gerar um PIX no WhatsApp com Woovi e BotConversa via Make](https://www.youtube.com/watch?v=5wdp1lCwyYY)
 

--- a/docs/intro/getting-started.md
+++ b/docs/intro/getting-started.md
@@ -34,7 +34,7 @@ Se a sua empresa utiliza SAML, poderá entrar automaticamente no Woovi SAML Serv
 
 ## Segurança e Firewall
 
-### Lista de Domínios Openpix permitidos
+### Lista de Domínios Woovi permitidos
 
 A fim de operar corretamente os usuários da sua empresa precisam ter acesso aos servidores da Woovi. A Woovi utiliza tecnologias web padrão e aplica a encriptação em todas as comunicações, na maioria dos casos a sua configuração deve funcionar fora da caixa, sem requisitos adicionais.
 
@@ -46,7 +46,7 @@ Se você se deparar com problemas utilizando a plataforma, por favor verifique o
 
 - Certifique-se de que não está bloqueando os e-mails do domínio da Woovi.
   
-  > Tem que listar todos os domínios permitidos da Openpix *.woovi.com em seu fornecedor de e-mail
+  > Tem que listar todos os domínios permitidos da Woovi *.woovi.com em seu fornecedor de e-mail
   
 - Não armazenar em cache
 

--- a/docs/test-environment/test-environment.md
+++ b/docs/test-environment/test-environment.md
@@ -43,39 +43,39 @@ Você poderá:
 
 ## Configurando o Single Sign-On (SSO)
 
-OpenPix suporta múltiplos SSO identity providers (IdP). Um Identity Provider é um servidor que pode fornecer informações de identidade sobre os usuários da sua empresa. Por exemplo, o Google pode ser um fornecedor de identidade para empresas que utilizam a solução G Suite. Se a sua empresa está utilizando a solução G Suite, pode entrar automaticamente na OpenPix utilizando a sua conta Google. então um servidor Google enviará a sua informação de identidade para esse site.
+A Woovi suporta múltiplos SSO identity providers (IdP). Um Identity Provider é um servidor que pode fornecer informações de identidade sobre os usuários da sua empresa. Por exemplo, o Google pode ser um fornecedor de identidade para empresas que utilizam a solução G Suite. Se a sua empresa está utilizando a solução G Suite, pode entrar automaticamente na Woovi utilizando a sua conta Google. então um servidor Google enviará a sua informação de identidade para esse site.
 
 ### Azure Single Sign On
 
-Se a sua empresa utiliza o Azure Single Sign On, poderá entrar automaticamente na OpenPix utilizando o Azure como IdP. Para utilizar esta estratégia de login, é preciso ativar esta opção no menu de definições.
+Se a sua empresa utiliza o Azure Single Sign On, poderá entrar automaticamente na Woovi utilizando o Azure como IdP. Para utilizar esta estratégia de login, é preciso ativar esta opção no menu de definições.
 
 ### Google Single Sign On
 
-Se a sua empresa utiliza a G Suite, poderá iniciar automaticamente uma sessão na OpenPix utilizando o Google como IdP.
+Se a sua empresa utiliza a G Suite, poderá iniciar automaticamente uma sessão na Woovi utilizando o Google como IdP.
 
 ### SAML Single Sign on
 
-Se a sua empresa utiliza SAML, poderá entrar automaticamente no OpenPix SAML Servers como IdP.
+Se a sua empresa utiliza SAML, poderá entrar automaticamente no Woovi SAML Servers como IdP.
 
 ## Segurança e Firewall
 
-### Lista de Domínios Openpix permitidos
+### Lista de Domínios Woovi permitidos
 
-A fim de operar corretamente os usuários da sua empresa precisam ter acesso aos servidores da OpenPix. A OpenPix utiliza tecnologias web padrão e aplica a encriptação em todas as comunicações, na maioria dos casos a sua configuração deve funcionar fora da caixa, sem requisitos adicionais.
+A fim de operar corretamente os usuários da sua empresa precisam ter acesso aos servidores da Woovi. A Woovi utiliza tecnologias web padrão e aplica a encriptação em todas as comunicações, na maioria dos casos a sua configuração deve funcionar fora da caixa, sem requisitos adicionais.
 
 Se você se deparar com problemas utilizando a plataforma, por favor verifique os seguintes requisitos:
 
-- Certifique-se que os domínios da OpenPix estão liberados seu servidor proxy ou firewall. Além disso seus clientes também devem ter poder acessar todos os domínios e subdomínios.
+- Certifique-se que os domínios da Woovi estão liberados seu servidor proxy ou firewall. Além disso seus clientes também devem ter poder acessar todos os domínios e subdomínios.
   
   > Permitir todo tráfego para OpenPix *.openpix.com.br 
   > Permitir todo tráfego para OpenPix *.openpix.com
 
-- Certifique-se de que não está bloqueando os e-mails do domínio da OpenPix.
+- Certifique-se de que não está bloqueando os e-mails do domínio da Woovi.
   
   > Permitir emails da Openpix *.openpix.com.br em seu fornecedor de e-mail
   > Permitir emails da Openpix *.openpix.com em seu fornecedor de e-mail
   
 - Não armazenar em cache
 
-    > Não alterar ou impor novas políticas de cache para conteúdo estático OpenPix ou endereço IP. 
-    > OpenPix utiliza uma rede CDN global e proteções adicionais de servidor para que os IPs mudem frequentemente e sem aviso prévio.
+    > Não alterar ou impor novas políticas de cache para conteúdo estático Woovi ou endereço IP. 
+    > A Woovi utiliza uma rede CDN global e proteções adicionais de servidor para que os IPs mudem frequentemente e sem aviso prévio.

--- a/docs/webhook/api/webhook-api.mdx
+++ b/docs/webhook/api/webhook-api.mdx
@@ -9,7 +9,7 @@ tags:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Pela Openpix é possível criar webhooks para interceptar quando um pix for realizado. Hoje, há duas maneiras de realizar a criação do mesmo: via plataforma ou API.
+Pela Woovi é possível criar webhooks para interceptar quando um pix for realizado. Hoje, há duas maneiras de realizar a criação do mesmo: via plataforma ou API.
 
 Neste tutorial iremos descrever como criar um webhook para interceptar a chegada de um novo Pix via uma chamada API.
 

--- a/docs/webhook/examples/languages.mdx
+++ b/docs/webhook/examples/languages.mdx
@@ -12,7 +12,7 @@ tags:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Com a Openpix é possível criar webhooks para interceptar quando um Pix for realizado.
+Com a Woovi é possível criar webhooks para interceptar quando um Pix for realizado.
 
 Neste tutorial iremos descrever como criar um webhook para informar o recebimento de um novo Pix e devolvê-lo em uma API registrada.
 

--- a/docs/webhook/platform/webhook-platform-api.mdx
+++ b/docs/webhook/platform/webhook-platform-api.mdx
@@ -10,7 +10,7 @@ tags:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Pela Openpix é possível criar webhooks para interceptar quando um pix for realizado. Hoje, há duas maneiras de realizar a criação do mesmo: via plataforma ou API.
+Pela Woovi é possível criar webhooks para interceptar quando um pix for realizado. Hoje, há duas maneiras de realizar a criação do mesmo: via plataforma ou API.
 
 Neste tutorial iremos descrever como criar um webhook para informar o recebimento de um novo Pix e devolvê-lo em uma API registrada.
 

--- a/docs/webhook/platform/webhook-platform-role.md
+++ b/docs/webhook/platform/webhook-platform-role.md
@@ -7,7 +7,7 @@ tags:
 - permission
 ---
 
-Pela Openpix é possível criar webhooks para interceptar quando um pix for realizado. Hoje, há duas maneiras de realizar a criação do mesmo: via plataforma ou API.
+Pela Woovi é possível criar webhooks para interceptar quando um pix for realizado. Hoje, há duas maneiras de realizar a criação do mesmo: via plataforma ou API.
 
 Para adicionar um novo usuário através da plataforma para ter acesso as funcionalidades de API e Webhook siga o seguinte passo a passo:
 

--- a/docs/webhook/seguranca/webhook-ips.md
+++ b/docs/webhook/seguranca/webhook-ips.md
@@ -7,7 +7,7 @@ tags:
   - ip
 ---
 
-Esta página lista os endereços IP que a Woovi/OpenPix usa para enviar webhooks.
+Esta página lista os endereços IP que a Woovi usa para enviar webhooks.
 
 **Para obter uma lista dos IPs que a Woovi Usa para enviar Webhooks basta entrar em contato com o time de suporte diretamente pelo chat da plataforma**
 

--- a/docs/webhook/webhook-test.md
+++ b/docs/webhook/webhook-test.md
@@ -7,12 +7,12 @@ tags:
 
 ## Validando o webhook de teste
 
-Quando é criado um novo webhook, a OpenPix envia uma requisição de teste para o seu endpoint. 
+Quando é criado um novo webhook, a Woovi envia uma requisição de teste para o seu endpoint. 
 Essa requisição é enviada para garantir que o seu endpoint está funcionando corretamente.
 
 ### 1. Recebendo o webhook de teste
 
-Quando a OpenPix envia um webhook de teste, o corpo da requisição é:
+Quando a Woovi envia um webhook de teste, o corpo da requisição é:
 
 ```json
 {


### PR DESCRIPTION
Continues the OpenPix cleanup (#721, #722), now removing the legacy **OpenPix** brand name from prose across the docs and pointing example data at a neutral domain.

## Brand mentions in prose
Replaced "OpenPix" / "Openpix" used as the company/platform name with "Woovi" in body text and headings — webhook intros, SSO/firewall section in the test environment and getting-started, versioning page, anticipation overview, WooCommerce order flow, and the dual-brand "Woovi/OpenPix" occurrences.

## Example data
- `charge/how-to-create-charge-with-split-to-subaccount-using-api.mdx`: the sample split `pixKey` now uses `destinatario@example.com` instead of `destinatario@openpix.com.br`.

## Deliberately left untouched (would break or is a real product name)
- Technical identifiers: webhook event names (`OPENPIX:CHARGE_COMPLETED`, …), API paths (`/api/openpix/v1/...`), HTTP headers (`X-OpenPix-Signature`), the plugin JS global (`window.$openpix`), the `@openpix/react` package, plugin slugs, release/asset filenames, GitHub repo links, and the RSA-signed / EMV-CRC example payloads.
- Real marketplace product names: the WooCommerce/Shopify/Magento plugins are literally published as "OpenPix", so those mentions stay accurate.
- The firewall/e-mail allowlist domains in `test-environment.md` (`*.openpix.com.br` / `*.openpix.com`) — left as-is since these are functional infra values I can't verify; see note below.

## Note for reviewers
`test-environment.md` still lists `*.openpix.com.br` / `*.openpix.com` in the firewall/e-mail allowlist, while the sibling `getting-started.md` lists `*.woovi.com` for the same purpose. If Woovi traffic/e-mail now originate from `woovi.com`, that allowlist is outdated and should be updated — but that's an infra fact worth confirming before changing, so it's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)