### PR TITLE
docs(invoice): correct the issuing guide and add the fields table

### DIFF
--- a/docs/invoice/how-to-issue-invoice-by-api.md
+++ b/docs/invoice/how-to-issue-invoice-by-api.md
@@ -10,13 +10,19 @@ tags:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::caution
+
+A emissão exige que a integração de nota fiscal da conta já esteja configurada e ativa. Veja [Configurando a emissão de nota fiscal via API](/docs/baas/baas-invoice-integration) ou [Como ativar a emissão pela plataforma](/docs/integrations/invoice/invoice-how-to-integrate).
+
+:::
+
 ## Endpoint
 
 ```http
 POST /api/v1/invoice
 ```
-Você encontra a documentação mais detalhada desse endpoint nas [documentações de api](https://developers.woovi.com/en/api#tag/invoice/paths/~1api~1v1~1invoice/post)
 
+Autentique com o header `Authorization: SEU_APPID_AQUI`. Você encontra a documentação detalhada desse endpoint nas [documentações de api](https://developers.woovi.com/en/api#tag/invoice/paths/~1api~1v1~1invoice/post).
 
 A API aceita dois formatos de payload, sempre exigindo dados de cobrança **ou** valor, e um cliente (via `customerId` ou objeto `customer`).
 
@@ -24,6 +30,7 @@ A API aceita dois formatos de payload, sempre exigindo dados de cobrança **ou**
 
 ```json
 {
+  "correlationID": "nfse-assinatura-pro-2025-08",
   "description": "Assinatura Pro - Agosto/2025",
   "billingDate": "2025-08-31T23:59:59.000Z",
   "value": 12990,
@@ -35,6 +42,7 @@ A API aceita dois formatos de payload, sempre exigindo dados de cobrança **ou**
 
 ```json
 {
+  "correlationID": "nfse-mensalidade-premium-2025-08",
   "description": "Mensalidade Premium",
   "billingDate": "2025-08-31T23:59:59.000Z",
   "charge": "ch_abc",
@@ -54,6 +62,34 @@ A API aceita dois formatos de payload, sempre exigindo dados de cobrança **ou**
 }
 ```
 
+### Campos do corpo da requisição
+
+| Campo                      | Tipo   | Obrigatório                                     | Descrição                                                                                       |
+| -------------------------- | ------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `correlationID`            | string | Sim                                             | Seu identificador único da nota fiscal. Não pode repetir dentro da mesma conta.                 |
+| `billingDate`              | string | Sim                                             | Data de competência/vencimento da nota, no formato `YYYY-MM-DD` ou ISO 8601.                    |
+| `charge`                   | string | Sim, se `value` não for enviado                 | `correlationID` de uma cobrança existente. O valor e o cliente da nota são obtidos da cobrança. |
+| `value`                    | number | Sim, se `charge` não for enviado                | Valor da nota **em centavos** (ex.: `12990` equivale a R$ 129,90).                              |
+| `customer`                 | object | Sim, quando emitir por `value` sem `customerId` | Dados do tomador do serviço, detalhados nas linhas seguintes.                                   |
+| `customerId`               | string | Não                                             | `correlationID` de um cliente já cadastrado, como alternativa a enviar o objeto `customer`.     |
+| `description`              | string | Não                                             | Descrição do serviço que aparece na NFS-e.                                                      |
+| `customer.taxID`           | string | Sim (dentro de `customer`)                      | CPF ou CNPJ do tomador, somente números.                                                        |
+| `customer.name`            | string | Sim (dentro de `customer`)                      | Nome ou razão social do tomador.                                                                |
+| `customer.email`           | string | Sim (dentro de `customer`)                      | E-mail válido do tomador.                                                                       |
+| `customer.phone`           | string | Sim (dentro de `customer`)                      | Telefone do tomador.                                                                            |
+| `customer.address`         | object | Sim (dentro de `customer`)                      | Endereço do tomador.                                                                            |
+| `customer.address.country` | string | Sim (dentro de `address`)                       | País do endereço.                                                                               |
+| `customer.address.zipcode` | string | Sim (dentro de `address`)                       | CEP do endereço.                                                                                |
+| `customer.address.street`  | string | Sim (dentro de `address`)                       | Logradouro.                                                                                     |
+| `customer.address.number`  | string | Sim (dentro de `address`)                       | Número do endereço.                                                                             |
+| `customer.address.state`   | string | Sim (dentro de `address`)                       | Sigla do estado brasileiro (ex.: `SP`).                                                         |
+
+:::info
+
+O `correlationID` é único por conta: cada conta tem o seu próprio espaço de identificadores, então o mesmo `correlationID` pode existir em contas diferentes.
+
+:::
+
 ## Resposta
 
 ### Sucesso (201)
@@ -61,27 +97,46 @@ A API aceita dois formatos de payload, sempre exigindo dados de cobrança **ou**
 ```json
 {
   "invoice": {
-    "id": "inv_123",
-    "status": "ISSUED",
-    "provider": "NFEIO",
-    "chargeId": "ch_abc",
-    "customerId": "cus_123",
+    "id": "6a5f62d35ab4cd72544b1a48",
+    "correlationID": "nfse-mensalidade-premium-2025-08",
     "value": 12990,
-    "links": {
-      "xml": "https://.../inv_123.xml",
-      "pdf": "https://.../inv_123.pdf"
+    "description": "Mensalidade Premium",
+    "date": "2025-08-31T23:59:59.000Z",
+    "billingDate": "2025-08-31T23:59:59.000Z",
+    "status": "PENDING",
+    "statusRaw": null,
+    "customer": {
+      "correlationID": "cus_123",
+      "name": "Maria Souza"
+    },
+    "charge": {
+      "correlationID": "ch_abc",
+      "value": 12990,
+      "status": "ACTIVE",
+      "paidAt": null,
+      "date": "2025-08-01T12:00:00.000Z"
     }
   }
 }
 ```
 
+A emissão é **assíncrona**. A resposta confirma que a nota foi registrada, não que ela já foi autorizada pela prefeitura — por isso o `status` volta como `PENDING`.
+
+### Fluxo de status
+
+```
+PENDING  →  PROCESSING  →  CONFIRMED
+```
+
+O PDF e o XML só ficam disponíveis depois que a nota atinge `CONFIRMED`.
+
 ### Erros (400)
 
-* `You need to configure the invoice integration`
-* `Customer not found`
-* `Customer is required`
-* `Charge not found`
-* `Customer address is invalid`
+- `You need to configure the invoice integration`
+- `Customer not found`
+- `Customer is required`
+- `Charge not found`
+- `Customer address is invalid`
 
 ### Exemplos em código
 
@@ -89,36 +144,63 @@ A API aceita dois formatos de payload, sempre exigindo dados de cobrança **ou**
   <TabItem value="shell-curl" label="Shell + cURL" default>
 
 ```sh
- curl --request POST \
-     --url https://api.woovi.com/api/v1/invoice \
-     --header 'Authorization: {AUTHORIZATION TOKEN}' \
-     --header 'content-type: application/json'\
-      -d '{
-        "description": "Mensalidade Premium",
-        "billingDate": "2025-08-31T23:59:59.000Z",
-        "charge": "ch_abc",
-        "customerId": "cus_123"
-      }'
+curl --request POST \
+  --url https://api.woovi.com/api/v1/invoice \
+  --header 'Authorization: {AUTHORIZATION TOKEN}' \
+  --header 'content-type: application/json' \
+  -d '{
+    "correlationID": "nfse-mensalidade-premium-2025-08",
+    "description": "Mensalidade Premium",
+    "billingDate": "2025-08-31T23:59:59.000Z",
+    "charge": "ch_abc",
+    "customerId": "cus_123"
+  }'
 ```
 
 </TabItem>
-<TabItem value="javascript" label="JavaScript + Fetch" default>
+<TabItem value="javascript" label="JavaScript + Fetch">
 
 ```js
-fetch('https://api.woovi.com/api/v1/invoice', {
+const response = await fetch('https://api.woovi.com/api/v1/invoice', {
   method: 'POST',
   headers: {
-    Authorization: {AUTHORIZATION TOKEN},
+    Authorization: '{AUTHORIZATION TOKEN}',
     'Content-Type': 'application/json',
   },
-  body: {
-    description: "Mensalidade Premium",
-    billingDate: "2025-08-31T23:59:59.000Z",
-    charge: "ch_abc",
-    customerId: "cus_123"
-  }
-}).then(async (res) => res.json)
+  body: JSON.stringify({
+    correlationID: 'nfse-mensalidade-premium-2025-08',
+    description: 'Mensalidade Premium',
+    billingDate: '2025-08-31T23:59:59.000Z',
+    charge: 'ch_abc',
+    customerId: 'cus_123',
+  }),
+});
+
+const data = await response.json();
 ```
 
   </TabItem>
 </Tabs>
+
+## Consultando as notas emitidas
+
+Use o endpoint de listagem para acompanhar o status da emissão:
+
+```http
+GET /api/v1/invoice
+```
+
+Parâmetros de query aceitos: `start` e `end` (filtro por data da nota), `skip` e `limit` (paginação).
+
+```sh
+curl --request GET \
+  --url 'https://api.woovi.com/api/v1/invoice?start=2025-08-01&end=2025-08-31&skip=0&limit=100' \
+  --header 'Authorization: {AUTHORIZATION TOKEN}'
+```
+
+Cada item da lista tem o mesmo formato do objeto `invoice` devolvido na criação.
+
+## Próximos passos
+
+- [Baixar o PDF e o XML da nota](/docs/invoice/how-to-get-invoice-files-by-api)
+- [Cancelar uma nota emitida](/docs/invoice/how-to-cancel-issued-invoice-by-api)


### PR DESCRIPTION
Follow-up to #726. That PR removed a duplicate issuing guide I had written; this one folds the parts worth keeping into the existing guide and fixes what the existing one got wrong.

## Corrections

All three checked against the service-invoice handler and its zod schema.

**1. Both payload examples were missing `correlationID`.** The REST schema requires it in either shape, so both examples as written return `400`.

**2. The 201 example showed `status: "ISSUED"`.** On creation the status is `PENDING` — issuing is asynchronous. `invoicePost.ts` says so outright: *"Create-time is money-free (Invoice{status:PENDING} + enqueue INVOICE:PROCESSING)"*.

**3. The 201 example showed fields that do not exist.** It had `provider`, `chargeId`, `customerId` and a `links` object with pdf/xml URLs. The actual response is:

```
{ id, correlationID, value, description, date, billingDate, status, statusRaw, customer, charge }
```

`customer` and `charge` are objects, and there is no `links` — the PDF and XML come from their own endpoints. Someone following the old example would have looked for URLs that never arrive.

## Additions

- **Table of every body field** — type, conditional requirement, and the nested `customer.address` keys. This was the biggest gap.
- `value` is **in cents** (the old example used `12990` without saying so).
- The status flow `PENDING → PROCESSING → CONFIRMED`, and that pdf/xml only become available at `CONFIRMED`.
- The listing endpoint `GET /api/v1/invoice` with its `start` / `end` / `skip` / `limit` parameters, for polling the status.
- A prerequisite note linking to the integration setup, plus next-steps links to the files and cancel guides.

## Also

The JavaScript example was not runnable: unquoted `{AUTHORIZATION TOKEN}`, `body` passed as an object rather than a JSON string, and `res.json` referenced without calling it. Fixed.

## Kept from the existing guide

The frontmatter and sidebar label, the two-payload-format structure, the `<Tabs>` code examples, and the list of 400 error messages — none of which my removed draft had.

## Testing

Prettier passes and all four internal links resolve to files that exist. I did not run `pnpm build` (RAM-constrained here), so the `<Tabs>` rendering is worth a glance on a local `pnpm start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)