### PR TITLE
docs(boleto): document the BOLETO_SETTLED webhook and the boleto transaction API

### DIFF
--- a/docs/boleto/boleto-out-reconciliation.md
+++ b/docs/boleto/boleto-out-reconciliation.md
@@ -15,16 +15,19 @@ tags:
 
 Depois de **pagar um boleto** pela API (fluxo *Boleto OUT* — veja
 **[Como pagar um boleto via API](/docs/boleto/boleto-out-api)**), o pagamento é
-processado de forma **assíncrona**. Este guia mostra as duas formas de
+processado de forma **assíncrona**. Este guia mostra as três formas de
 **conciliar** e saber que o boleto foi efetivamente pago:
 
 | Forma | Quando usar |
 | --- | --- |
 | **Webhook `OPENPIX:MOVEMENT_CONFIRMED`** | Você quer ser **avisado** no momento em que o pagamento é confirmado, sem ficar consultando a API. |
-| **`GET /api/v1/payment/{id}`** | Você quer **consultar** o estado atual do pagamento pontualmente (polling ou verificação sob demanda). |
+| **`GET /api/v1/payment/{id}`** | Você quer **consultar** o estado atual de **um** pagamento pontualmente (polling ou verificação sob demanda). |
+| **`GET /api/v1/boleto-transaction`** | Você quer conciliar **em lote**, listando todos os boletos pagos em um período — e precisa da **tarifa** cobrada em cada um. |
 
-Nas duas formas, a amarração com a sua operação é feita pelo **`correlationID`**
-que você definiu na criação do pagamento.
+Nas duas primeiras formas, a amarração com a sua operação é feita pelo
+**`correlationID`** que você definiu na criação do pagamento. A terceira atende
+aos dois casos: **listar** as transações de um período ou consultar **uma**
+transação específica pelo **`boletoTransactionID`**, o id público da transação.
 
 :::note Valores em centavos
 Todos os valores (`value`) são expressos em **centavos** (`300` = R$ 3,00).
@@ -147,6 +150,95 @@ Concilie olhando o campo **`payment.status`**:
 
 ---
 
+## Forma 3 — Listar as transações de boleto (`GET /api/v1/boleto-transaction`)
+
+As duas formas anteriores respondem sobre **um** pagamento. Quando o que você
+precisa é fechar um período — conferir tudo que foi pago entre duas datas, com a
+**tarifa** de cada boleto — use a API de transações de boleto.
+
+Filtre por `type=BOLETO_OUT` para trazer apenas os boletos que a **sua empresa
+pagou** (sem `BOLETO_OUT`, a listagem também traz os boletos que os seus
+pagadores pagaram):
+
+```bash
+curl --request GET \
+  --url 'https://api.woovi.com/api/v1/boleto-transaction?type=BOLETO_OUT&start=2026-07-01T00:00:00.000Z&end=2026-07-31T23:59:59.000Z' \
+  --header 'Authorization: {APP_ID}'
+```
+
+```json
+{
+  "status": "OK",
+  "pageInfo": {
+    "skip": 0,
+    "limit": 100,
+    "hasPreviousPage": false,
+    "hasNextPage": false
+  },
+  "boletoTransactions": [
+    {
+      "boletoTransactionID": "btx_019f6123d8ff7332a4a16de2ed15a3cb",
+      "type": "BOLETO_OUT",
+      "status": "CONFIRMED",
+      "value": 3827,
+      "fee": 115,
+      "createdAt": "2026-07-14T14:59:27.103Z"
+    }
+  ]
+}
+```
+
+Concilie pelo campo **`status`**: **`CONFIRMED`** é o boleto pago. O **`value`** é
+o valor que saiu da sua conta e o **`fee`** é a tarifa cobrada pela operação.
+
+Para o detalhe de **uma** transação, consulte pelo `boletoTransactionID` — é o
+mesmo id que a listagem devolve e que você pode guardar na sua base para conferir
+a transação depois, sem varrer o período de novo:
+
+```bash
+curl --request GET \
+  --url https://api.woovi.com/api/v1/boleto-transaction/btx_019f6123d8ff7332a4a16de2ed15a3cb \
+  --header 'Authorization: {APP_ID}'
+```
+
+```json
+{
+  "boletoTransaction": {
+    "boletoTransactionID": "btx_019f6123d8ff7332a4a16de2ed15a3cb",
+    "type": "BOLETO_OUT",
+    "status": "CONFIRMED",
+    "value": 3827,
+    "fee": 115,
+    "createdAt": "2026-07-14T14:59:27.103Z"
+  }
+}
+```
+
+:::note De onde vem o `boletoTransactionID`
+No **boleto OUT** o id vem da **listagem**: o webhook `OPENPIX:MOVEMENT_CONFIRMED`
+não o inclui — ele identifica o pagamento pelo `payment.correlationID`. Já no
+**boleto IN** o id chega direto no webhook `BOLETO_SETTLED`, e aí você consulta a
+transação sem listar nada — veja
+**[Conciliação de liquidação do Boleto](/docs/boleto/boleto-reconciliation)**.
+:::
+
+:::note Escopos da aplicação
+A listagem exige o escopo **`BOLETO_TRANSACTION_GET_LIST`** e o detalhe exige
+**`BOLETO_TRANSACTION_GET`**. Sem o escopo correspondente a chamada responde
+**`403`**.
+:::
+
+:::note Boleto OUT não tem `settledAt` nem `charge`
+Esses dois campos aparecem só em transações **`BOLETO_IN`** — a liquidação é o
+crédito na sua conta de um boleto que o seu pagador pagou. No `BOLETO_OUT` o
+estado final é o **`status`** `CONFIRMED`.
+:::
+
+Os filtros de data (`start`/`end`) e a paginação (`skip`/`limit`) estão descritos
+na **[referência da API](https://developers.woovi.com/api#tag/boleto)**.
+
+---
+
 ## Fluxo recomendado
 
 1. Crie e aprove o pagamento com um `correlationID` próprio da sua operação
@@ -156,3 +248,6 @@ Concilie olhando o campo **`payment.status`**:
 3. Como alternativa ou reforço, consulte **`GET /api/v1/payment/{correlationID}`**
    e verifique `payment.status` até chegar em `CONFIRMED` (pago) ou `FAILED`
    (falha).
+4. No fechamento do dia ou do mês, rode **`GET /api/v1/boleto-transaction?type=BOLETO_OUT`**
+   com o período desejado para conferir todos os pagamentos de uma vez e apurar as
+   tarifas.

--- a/docs/boleto/boleto-reconciliation.md
+++ b/docs/boleto/boleto-reconciliation.md
@@ -25,9 +25,13 @@ O webhook de boleto (**`OPENPIX:CHARGE_COMPLETED`**) é disparado no
 Para conferência financeira (bater o valor recebido com a venda) e liberação de
 produto, o momento que importa é a **liquidação**.
 
-Este guia mostra como, a partir do webhook de pagamento, acompanhar a
-**liquidação** consultando a **API de cobrança** pelo status **`SETTLED`** e pelo
-campo **`settledAt`** do método de pagamento `boleto`.
+Para a liquidação você tem três caminhos, do mais recomendado ao de reforço:
+
+| Forma | Quando usar |
+| --- | --- |
+| **Webhook `BOLETO_SETTLED`** | Você quer ser **avisado** no momento em que o valor é creditado, sem polling. É o caminho recomendado. |
+| **`GET /api/v1/boleto-transaction`** | Você quer conciliar **em lote**, listando o que liquidou em um período (filtro por `settledStart`/`settledEnd`). |
+| **API de cobrança pelo `correlationID`** (`paymentMethods.boleto.status` = `SETTLED` + `settledAt`) | Você já integra a cobrança e quer verificar **uma** venda pontualmente, pelo mesmo `correlationID` que já usa. |
 
 ---
 
@@ -159,15 +163,128 @@ Valores monetários (`value`, `fee`) são expressos em **centavos**
 
 ---
 
+## Webhook de liquidação — `BOLETO_SETTLED`
+
+Em vez de consultar a cobrança até virar `SETTLED`, você pode receber o webhook
+**`BOLETO_SETTLED`**, disparado no momento em que o valor é **creditado na sua
+conta**. Ele dispensa o polling do passo anterior.
+
+O corpo repete os blocos `charge` e `boleto` do `OPENPIX:CHARGE_COMPLETED` de
+boleto — quem já trata o evento de pagamento reaproveita o mesmo parsing — e
+acrescenta o **`boleto.settledAt`**:
+
+```json
+{
+  "event": "BOLETO_SETTLED",
+  "charge": {
+    "correlationID": "minha-venda-123",
+    "value": 242898,
+    "status": "COMPLETED"
+  },
+  "boleto": {
+    "boletoTransactionID": "btx_019fa55beec9775faf8a069d64dcde54",
+    "value": 245000,
+    "status": "SETTLED",
+    "boletoBarcode": "34191120100002428981103069645110772982609000",
+    "boletoDigitable": "34191103036964511077129826090002112010000242898",
+    "fee": 299,
+    "settledAt": "2026-07-27T10:00:00.000Z"
+  }
+}
+```
+
+Amarre pelo **`charge.correlationID`**, o mesmo que você já usa no evento de
+pagamento.
+
+:::note `boleto.value` pode ser maior que `charge.value`
+`charge.value` é o valor **emitido**; `boleto.value` é o que o pagador
+**efetivamente pagou**, que fica acima do emitido quando o boleto é pago depois do
+vencimento (juros e multa). Concilie o crédito pelo `boleto.value`.
+:::
+
+Guarde o **`boletoTransactionID`**: é o id público da transação, e com ele você
+consulta o detalhe na API abaixo.
+
+Para configurar a URL e validar a assinatura, veja
+**[Webhook](/docs/webhook/webhook-events-type)**.
+
+---
+
+## Conciliação em lote — `GET /api/v1/boleto-transaction`
+
+Para fechar um período, liste as transações filtrando pela **data de liquidação**
+(`settledStart` / `settledEnd`) e por `type=BOLETO_IN`:
+
+```bash
+curl --request GET \
+  --url 'https://api.woovi.com/api/v1/boleto-transaction?type=BOLETO_IN&settledStart=2026-07-01T00:00:00.000Z&settledEnd=2026-07-31T23:59:59.000Z' \
+  --header 'Authorization: {APP_ID}'
+```
+
+```json
+{
+  "status": "OK",
+  "pageInfo": {
+    "skip": 0,
+    "limit": 100,
+    "hasPreviousPage": false,
+    "hasNextPage": false
+  },
+  "boletoTransactions": [
+    {
+      "boletoTransactionID": "btx_019fa55beec9775faf8a069d64dcde54",
+      "type": "BOLETO_IN",
+      "status": "CONFIRMED",
+      "value": 245000,
+      "fee": 299,
+      "createdAt": "2026-07-26T13:04:11.212Z",
+      "settledAt": "2026-07-27T10:00:00.000Z",
+      "charge": {
+        "value": 242898,
+        "status": "COMPLETED",
+        "boletoBarcode": "34191120100002428981103069645110772982609000",
+        "boletoDigitable": "34191103036964511077129826090002112010000242898"
+      }
+    }
+  ]
+}
+```
+
+Existem **dois intervalos de data independentes**, porque respondem perguntas
+diferentes: `start`/`end` filtram por **criação** e `settledStart`/`settledEnd`
+por **liquidação**. Para conferência financeira use o de liquidação — as duas datas
+voltam em todo item, então dá para bater uma contra a outra.
+
+O detalhe de uma transação sai pelo id recebido no webhook:
+
+```bash
+curl --request GET \
+  --url https://api.woovi.com/api/v1/boleto-transaction/btx_019fa55beec9775faf8a069d64dcde54 \
+  --header 'Authorization: {APP_ID}'
+```
+
+:::note Escopos da aplicação
+A listagem exige **`BOLETO_TRANSACTION_GET_LIST`** e o detalhe exige
+**`BOLETO_TRANSACTION_GET`**. Sem o escopo, a chamada responde **`403`**.
+:::
+
+---
+
 ## Fluxo recomendado
 
 1. Crie a cobrança com um `correlationID` próprio da sua venda.
 2. Ao receber `OPENPIX:CHARGE_COMPLETED`, marque a venda como **paga** e guarde o
    `correlationID` da charge (`charge.correlationID`).
-3. Consulte a API de cobrança pelo `correlationID` e verifique
-   `paymentMethods.boleto.status`. Quando for **`SETTLED`**, use
-   `paymentMethods.boleto.settledAt` como a **data de liquidação**, concilie o
-   recebimento e libere o produto.
+3. Assine o webhook **`BOLETO_SETTLED`**. Ao recebê-lo, use `boleto.settledAt` como
+   a **data de liquidação**, concilie o recebimento pelo `boleto.value` e libere o
+   produto. Guarde o `boleto.boletoTransactionID`.
+4. No fechamento do período, rode
+   **`GET /api/v1/boleto-transaction?type=BOLETO_IN`** com `settledStart`/`settledEnd`
+   para conferir tudo que liquidou de uma vez.
+5. Se preferir não depender de webhook, consulte a API de cobrança pelo
+   `correlationID` e verifique `paymentMethods.boleto.status`. Quando for
+   **`SETTLED`**, use `paymentMethods.boleto.settledAt` como a **data de
+   liquidação**, concilie o recebimento e libere o produto.
 
 ---
 

--- a/docs/webhook/webhook-events-type.md
+++ b/docs/webhook/webhook-events-type.md
@@ -127,6 +127,15 @@ Esse evento é enviado quando uma disputa é cancelada
 
 [Ver exemplo de payload →](/docs/webhook/examples/webhook-canceled-payload)
 
+## Eventos de boleto
+
+### BOLETO_SETTLED
+Esse evento é enviado quando um boleto é **liquidado**, ou seja quando o valor é creditado na sua conta — o que acontece em até 3 dias úteis após o pagamento, e não no ato dele. O pagamento em si é notificado pelo `OPENPIX:CHARGE_COMPLETED`.
+
+O corpo repete os blocos `charge` e `boleto` do evento de cobrança paga e acrescenta o `boleto.settledAt`, além do `boleto.boletoTransactionID`, que é o id usado para consultar a transação na API.
+
+[Ver como conciliar →](/docs/boleto/boleto-reconciliation)
+
 ## Eventos de Registro de contas 
 
 ### ACCOUNT_REGISTER_APPROVED


### PR DESCRIPTION
## Why

Two things shipped for boleto that the docs never covered:

- **`BOLETO_SETTLED`**, the webhook fired when a boleto IN is settled — the money credited to the merchant, which happens up to 3 business days after the payment. Until now the settlement guide only taught polling the charge API, and the webhook events page had no boleto section at all.
- **`GET /api/v1/boleto-transaction`**, listing and detail, which is what makes closing a period possible (and is the only place the **fee** of each boleto is exposed).

## What

**`docs/boleto/boleto-reconciliation.md`** (boleto IN). The summary now presents the three routes to the settlement, ordered by what to reach for first. Two new sections: the `BOLETO_SETTLED` webhook with its payload, and batch reconciliation filtered by `settledStart`/`settledEnd`. The existing "Passo 2" polling section is untouched and stays as the alternative — the recommended flow still spells out consulting by `correlationID` and reading `paymentMethods.boleto.status` / `settledAt`.

**`docs/boleto/boleto-out-reconciliation.md`** (boleto OUT). This one already documented `OPENPIX:MOVEMENT_CONFIRMED` and `GET /api/v1/payment/{id}`, so what was missing was the API: a third route with `type=BOLETO_OUT`, both the listing and the single-transaction lookup, plus the scopes.

**`docs/webhook/webhook-events-type.md`**. New "Eventos de boleto" section registering `BOLETO_SETTLED`.

### Details worth reviewing

- Payloads were taken from the code, not written from memory: `buildBoletoSettledWebhookPayload.ts` for the webhook and the endpoint handlers for the API. `boleto.status: "SETTLED"` is accurate because `updateBoletoStatusSettled` sets the payment method to `SETTLED` before the webhook is dispatched.
- The guides warn that `boleto.value` can exceed `charge.value` — the emitted amount stays in `charge.value` while the payer paid interest and fine. Reconciling on the wrong one is the easy mistake here.
- The webhook is documented **only** on the boleto IN page. `BOLETO_SETTLED` is for a settled boleto IN; boleto OUT is confirmed by `OPENPIX:MOVEMENT_CONFIRMED`.
- The OUT page states where the `boletoTransactionID` comes from, because it differs per flow: on IN it arrives in the webhook, on OUT the `OPENPIX:MOVEMENT_CONFIRMED` payload does not carry it, so it comes from the listing. Worth closing that asymmetry separately.
- Existing headings were not renumbered, so no anchor that other pages or external links point at changes.

## Test plan

`docusaurus build --locale pt-BR` succeeds, and the new content is present in the generated output (`BOLETO_SETTLED`, the new section, `settledStart`, the scopes).

The build reports one broken anchor on the OUT page, `webhook-events-type#openpixmovement_confirmed`. It is pre-existing — the same link is on `main`, it only moved down a few lines here — and the heading it points at does exist, so the slug is what disagrees. Left alone to keep this PR to the content.

Only `docs/` is included. The regenerated `src/swaggers/*`, `static/wooviPostman.json` and `ApiExplorer/endpoints.ts` are a separate concern and come with their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)