### PR TITLE
docs(boleto): documentar endereço do cliente obrigatório na criação de boleto

### DIFF
--- a/docs/boleto/boleto-api.md
+++ b/docs/boleto/boleto-api.md
@@ -30,6 +30,23 @@ Para criar uma cobrança do tipo *Boleto* você precisará acessar o endpoint de
 
 O processo de criaçao de um boleto é bem simples. Basta utilizar o mesmo endpoint que o de cobrança, porém, com a adição do parâmetro `type` com o valor `BOLETO`.
 
+:::warning Endereço do cliente é obrigatório
+Diferente de uma cobrança Pix, o Boleto **exige os dados do cliente (`customer`), incluindo o endereço completo (`address`)**. Caso algum campo do endereço esteja ausente, a criação da cobrança falha com um erro como `{"error":"O código do estado do cliente é obrigatório"}`.
+
+Os campos obrigatórios do cliente são:
+
+- `name` — nome do cliente
+- `taxID` — CPF/CNPJ do cliente
+- `address.street` — logradouro
+- `address.number` — número
+- `address.zipcode` — CEP
+- `address.neighborhood` — bairro
+- `address.city` — cidade
+- `address.state` — sigla do estado (UF, ex.: `SP`)
+
+O campo `address.complement` é opcional.
+:::
+
 ```json
 {
   "correlationID": "9134e286-6f71-427a-bf00-241681624587",
@@ -40,7 +57,16 @@ O processo de criaçao de um boleto é bem simples. Basta utilizar o mesmo endpo
     "name": "Dan",
     "taxID": "31324227036",
     "email": "email0@example.com",
-    "phone": "5511999999999"
+    "phone": "5511999999999",
+    "address": {
+      "street": "Av. Paulista",
+      "number": "1000",
+      "complement": "Sala 10",
+      "zipcode": "01310100",
+      "neighborhood": "Bela Vista",
+      "city": "São Paulo",
+      "state": "SP"
+    }
   },
   "additionalInfo": [
     {
@@ -67,7 +93,7 @@ A resposta deve ser algo como:
 		"customer": {
 			"name": "Dan",
 			"email": "email0@example.com",
-			"phone": "+5511999999999",
+			"phone": "+551****9999",
 			"taxID": {
 				"taxID": "31324227036",
 				"type": "BR:CPF"
@@ -124,6 +150,3 @@ A resposta deve ser algo como:
 ```
 
 A criação de um boleto também gera um pix. É possível pagar com qualquer uma das duas opções.
-
-
-


### PR DESCRIPTION
## Contexto

Ao criar uma cobrança `type: BOLETO` (reportado pela empresa **PURPLE BOX**), a API retorna:

```json
{"error":"O código do estado do cliente é obrigatório"}
```

## Causa raiz

O exemplo de request na doc de Boleto ([/docs/boleto/boleto](https://developers.woovi.com/docs/boleto/boleto)) envia `customer` **sem `address`**. Porém, a validação do boleto exige o endereço completo do cliente. Confirmado no código (monorepo `woovi`), nos dois providers:

- `packages/boleto-provider-woovi/src/provider/wooviBoletoProviderPaymentMethodValidate.ts`
- `packages/boleto-provider-itau/src/provider/itauBoletoProviderPaymentMethodValidate.ts`

Ambos validam `customer.address` com os campos obrigatórios: `street`, `number`, `zipcode`, `neighborhood`, `city`, `state` (`complement` é opcional). A mensagem "O código do estado do cliente é obrigatório" corresponde ao i18n `Customer state code is required`, disparado quando `address.state` está ausente.

Ou seja: **não é bug de código, é a doc que está incompleta.**

## Mudança

- Adiciona o bloco `address` completo ao exemplo de request de criação de boleto.
- Adiciona um `:::warning` listando todos os campos obrigatórios do `customer` para BOLETO.

## Validação

Root cause confirmado lendo os schemas yup dos dois providers de boleto no checkout real da LXC. Confiança: **alta**.