### PR TITLE
docs(openapi): fix 7 contract errors in woovi.json (validated against code)

### DIFF
--- a/docs/baas/kyc/woovi-kyc-react.mdx
+++ b/docs/baas/kyc/woovi-kyc-react.mdx
@@ -22,7 +22,7 @@ Biblioteca React open-source que implementa um wizard completo de KYC Onboarding
 **Links:** [GitHub](https://github.com/jgcmarins/woovi-kyc) · [npm](https://www.npmjs.com/package/woovi-kyc) · [Demo](https://woovi-kyc-demo.vercel.app/) · [Documentação completa](https://woovi-kyc-docs.vercel.app/)
 
 :::info Biblioteca da Comunidade
-Esta biblioteca foi criada pela comunidade e **não é mantida oficialmente pela Woovi**. Para a API oficial de KYC Onboarding, consulte os [Primeiros Passos](/docs/kyc/kyc-api-getting-started) e [Como criar um onboarding via API](/docs/kyc/kyc-api-onboarding-create).
+Esta biblioteca foi criada pela comunidade e **não é mantida oficialmente pela Woovi**. Para a API oficial de KYC Onboarding, consulte os [Primeiros Passos](/docs/baas/kyc/kyc-api-getting-started) e [Como criar um onboarding via API](/docs/baas/kyc/kyc-api-onboarding-create).
 :::
 
 ## Instalação
@@ -99,7 +99,7 @@ function App() {
 
 ## Integração com a API Woovi
 
-O wizard coleta todos os dados necessários para o endpoint [`POST /api/v1/kyc/onboarding`](/docs/kyc/kyc-api-onboarding-create). No callback `onSubmit`, envie os dados para seu backend que então encaminha para a API Woovi:
+O wizard coleta todos os dados necessários para o endpoint [`POST /api/v1/kyc/onboarding`](/docs/baas/kyc/kyc-api-onboarding-create). No callback `onSubmit`, envie os dados para seu backend que então encaminha para a API Woovi:
 
 ```tsx
 <KYCWizard

--- a/docs/charge/how-to-create-charge-woovi-parcelado.mdx
+++ b/docs/charge/how-to-create-charge-woovi-parcelado.mdx
@@ -65,7 +65,7 @@ Renderizar sua cobrança woovi Parcelado com o link de pagamento é a forma mais
 
 ### Renderizando a cobrança - Plugin Js
 
-Você encontra as docs sobre como renderiza-la clicando [aqui](/docs/plugin#come%C3%A7ando-com-o-plugin-de-order).
+Você encontra as docs sobre como renderiza-la clicando [aqui](/docs/plugin#come%C3%A7ando-com-o-plugin-de-widget).
 
 Siga os steps abaixo:
 

--- a/docs/ecommerce/magento1/magento1-plugin.mdx
+++ b/docs/ecommerce/magento1/magento1-plugin.mdx
@@ -39,7 +39,7 @@ Encontrando a pasta que contenha essas citadas basta realizar o seguinte:
 - Copiar os arquivos extraídos do .zip;
 - Colar dentro dessa pasta
 
-## 2. Configurando o Plugin Magento1
+## 2. Configurando o Plugin Magento1 {#configurando-o-plugin-magento1}
 
 Entre em Magento1 Admin -> System > Configuration > Sales (side menu) > Payment Methods
 
@@ -57,7 +57,7 @@ Ao acessar `Payment Methods` você irá notar o Collapsible `Woovi - Pix`
 - **Enabled** Ativar/Desativar o plugin como método de pagamento
 - **Title** Título do método de pagamento em sua loja Magento1
 
-### 2.2 Configurando CPF/CNPJ para o Customer (opcional)
+### 2.2 Configurando CPF/CNPJ para o Customer (opcional) {#configurando-cpfcnpj-para-o-customer-opcional}
 
 Para salvar o cpf/cnpj do customer da order na sua cobrança Woovi é necessário que seja ativado o campo `TaxVat` em sua loja Magento.
 

--- a/docs/ecommerce/woocommerce/woocommerce-nextmove.md
+++ b/docs/ecommerce/woocommerce/woocommerce-nextmove.md
@@ -11,7 +11,7 @@ tags:
 ## Integrando a Woovi com o NextMove
 
 1. Instale o Plugin Woovi na sua instância WooCommerce
-2. Configure o Plugin WooCommerce [aqui](woocommerce-plugin.md)
+2. Configure o Plugin WooCommerce [aqui](woocommerce-plugin.mdx)
 3. Dentro do plugin do NextMove, vá em `Configurações` > `Edit/rules` da página `Thank You`
 
 ![NextMove-settings](/img/ecommerce/woocommerce/woocommerce-nextmove-settings.png)

--- a/docs/ecommerce/woocommerce/woocommerce-plugin.mdx
+++ b/docs/ecommerce/woocommerce/woocommerce-plugin.mdx
@@ -50,7 +50,7 @@ Entre em WooCommerce -> Settings > Payments.
 
 ### Clique em `Manage` no Plugin Woovi
 
-- [ ] Cadastre um AppID do tipo API. Crie um appID [aqui](../apis/getting-started-api)
+- [ ] Cadastre um AppID do tipo API. Crie um appID [aqui](../../apis/api-getting-started)
 - [ ] Customize o Título, Descrição e Texto de Botão de Pedido
 
 ![Setup](/img/ecommerce/woocommerce-setup.png)

--- a/docs/ecommerce/woocommerce/woocommerce-subscriptions.md
+++ b/docs/ecommerce/woocommerce/woocommerce-subscriptions.md
@@ -19,7 +19,7 @@ Após configurar o plugin Woovi, será possível cobrar clientes recorrentemente
 
 ## 1. Instale e configure o Plugin Woovi
 
-Siga nossa documentação para instalar e configurar o Plugin Woovi: [Integrando a Woovi com WooCommerce](./woocommerce-plugin.md)
+Siga nossa documentação para instalar e configurar o Plugin Woovi: [Integrando a Woovi com WooCommerce](./woocommerce-plugin.mdx)
 
 ## 2. Ative o plugin WooCommerce Subscriptions
 

--- a/docs/partnerships/how-to-integrate-as-woovi-partner.md
+++ b/docs/partnerships/how-to-integrate-as-woovi-partner.md
@@ -30,7 +30,7 @@ https://app.woovi.com/register?partner=Q29tcGFue23AdDLOK2NhZGVjZTZkMzQ4MTQ3MzEyZ
 
 - Nova Empresa  
 Onde você pode criar um pré-registro para alguma empresa que deseja se tornar sua afiliada  
-Você pode fazer a criação da nova empresa através da nossa API, para saber mais bastar seguir a seção [como criar um afiliado via API](#como-criar-um-afiliado-via-api)
+Você pode fazer a criação da nova empresa através da nossa API, para saber mais bastar seguir a seção [como criar um afiliado via API](#como-criar-uma-empresa-afiliada-via-api)
 
 
 ![](./__assets__/how-to-integrate-as-woovi-partner/afilliate-link-and-new-company.png)

--- a/docs/payment/payment-how-to-auto-approve.md
+++ b/docs/payment/payment-how-to-auto-approve.md
@@ -79,7 +79,7 @@ Consultando o pagamento depois de confirmado, a resposta inclui `transaction` e 
 
 ## Comportamento sem o flag
 
-Quando `autoApprove` é omitido ou `false`, o pagamento é criado normalmente com status `CREATED` e pode ser aprovado posteriormente via [`POST /api/v1/payment/approve`](./payment-how-to-use-api-to-approve.md).
+Quando `autoApprove` é omitido ou `false`, o pagamento é criado normalmente com status `CREATED` e pode ser aprovado posteriormente via [`POST /api/v1/payment/approve`](./payment-how-to-use-api-to-approve-a-payment.md).
 
 ```json
 {

--- a/docs/payment/payment-how-to-use-api-to-approve-a-payment.md
+++ b/docs/payment/payment-how-to-use-api-to-approve-a-payment.md
@@ -12,7 +12,7 @@ tags:
 
 Nós disponibilizamos o _endpoint_ `/api/v1/payment/approve` para que você possa approvar um pagamento criado a partir da sua respectiva empresa filiada
 
-Você pode acessar [aqui]([https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment~1approve/post](https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment~1approve/post))
+Você pode acessar [aqui](https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment~1approve/post)
 a documentação referente a esse _endpoint_.
 
 Como parte do `body` da requisição, esperamos o envio dos seguintes itens: `correlationID`:

--- a/docs/payment/payment-how-to-use-api-to-create.mdx
+++ b/docs/payment/payment-how-to-use-api-to-create.mdx
@@ -15,7 +15,7 @@ import TabItem from '@theme/TabItem';
 Nós disponibilizamos o _endpoint_ `/api/v1/payment` para que você possa criar
 um novo _payment_ para a respectiva empresa afiliada.
 
-Você pode acessar [aqui](<[https://developers.woovi.com/api#tag/payment-(request-access)/paths/~1api~1v1~1payment/post](https://developers.woovi.com/api#tag/payment-(request-access)/paths/~1api~1v1~1payment/post)>)
+Você pode acessar [aqui](https://developers.woovi.com/api#tag/payment-(request-access)/paths/~1api~1v1~1payment/post)
 a documentação referente a esse _endpoint_.
 
 Como parte do `body` da requisição, possuímos dois modos de pagamento, por chave Pix e por QR Code:

--- a/docs/plugin/app-id.md
+++ b/docs/plugin/app-id.md
@@ -14,7 +14,7 @@ O appID é criado dentro da plataforma Woovi pelo administrador. Para criá-lo, 
 > 
 > Caso você não possua uma das permissão solicite para o admin da sua plataforma a inserção da mesma para seu usuário.
 > 
-> O usuário admin pode seguir este tutorial para [atualizar permissões de usuários](/docs/FAQ/faq-users)
+> O usuário admin pode seguir este tutorial para [atualizar permissões de usuários](/docs/faq/faq-users)
 
 Uma vez criada a API, copie o AppID para utilizar na integração do Plugin e siga para o próximo passo clicando em próximo no canto inferiro direito.
 

--- a/docs/plugin/plugin.md
+++ b/docs/plugin/plugin.md
@@ -8,7 +8,7 @@ A Woovi possui 2 plugins para ser utilizados em seu negócio, o Plugin de `Order
 
 ## O que é necessário saber antes de utilizar os plugins?
 
-- É necessário entender que para utilizar as API's e plugins disponibilizados dentro da Woovi você precisa ter um AppID válido, veja como criar [aqui](./app-id).
+- É necessário entender que para utilizar as API's e plugins disponibilizados dentro da Woovi você precisa ter um AppID válido, veja como criar [aqui](./app-id.md).
 
 - Ao tentar consumir o plugin para criar uma cobrança você precisa gerar um correlationID único, para conseguir buscar essa cobrança dentro da Woovi, se você não informar um novo correlationID para uma nova cobrança, sera mostrado a cobrança anterior relacionada a esse correlationID
 
@@ -54,7 +54,7 @@ Para confirmar se o plugin foi inicializado corretamente, você pode acessar o c
 ### Inicializando o plugin `Widget`
 
 O plugin é consumido usando o objeto `Window` nativo da API Javascript. Para inicializar, crie um array `$openpix` window para se comunicar com o plugin.
-Insira a chave do seu [appID](./app-id) como abaixo:
+Insira a chave do seu [appID](./app-id.md) como abaixo:
 
 ```jsx
 window.$openpix = window.$openpix || []; // priorize o objeto já instanciado

--- a/docs/qrcode-static/qrcode-static.md
+++ b/docs/qrcode-static/qrcode-static.md
@@ -15,7 +15,7 @@ Ele permite decidir um valor predeterminado ou deixar o pagador escolher o valor
 ## Casos de Uso
 
 - Aceitar pagamentos em eventos presenciais
-- Aceitar pagamentos em lives [https://www.twitch.tv/](Twitch)
+- Aceitar pagamentos em lives [Twitch](https://www.twitch.tv/)
 - Aceitar doações
 - Aceitar pagamentos em lojas físicas
 - Aceitar pagamentos em `vending maching`

--- a/docs/sdk/php/resources.md
+++ b/docs/sdk/php/resources.md
@@ -465,7 +465,7 @@ $client->payments();
 
 Crie uma solicitação de pagamento chamando o método `create` no recurso de pagamentos.
 
-[Documentação do endpoint para mais detalhes]([https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment/post](https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment/post)).
+[Documentação do endpoint para mais detalhes](https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment/post).
 
 ```php
 $payment = [
@@ -508,7 +508,7 @@ $result = $client->payments()->create($payment);
 
 Chame o método `getOne` no recurso de pagamentos para obter uma solicitação de pagamento a partir de um ID de pagamento ou correlationID.
 
-[Documentação do endpoint para mais detalhes]([https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment~1%7Bid%7D/get](https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment~1%7Bid%7D/get)).
+[Documentação do endpoint para mais detalhes](https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment~1%7Bid%7D/get).
 
 ```php
 $paymentOrCorrelationID = "id";
@@ -548,7 +548,7 @@ $result = $client->payments()->getOne($paymentOrCorrelationID);
 
 Chame o método `list` no recurso de pagamentos passando parâmetros de consulta que irá retornar um paginador com pagamentos:
 
-[Documentação do endpoint para mais detalhes]([https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment/get](https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment/get)).
+[Documentação do endpoint para mais detalhes](https://developers.woovi.com.br/api#tag/payment-(request-access)/paths/~1api~1v1~1payment/get).
 
 ```php
 $paginator = $client->payments()->list();

--- a/docs/subaccount/how-to-get-balance-and-detais-of-subaccount-using-api.mdx
+++ b/docs/subaccount/how-to-get-balance-and-detais-of-subaccount-using-api.mdx
@@ -16,7 +16,7 @@ Para a utilização desta funcionalidade é necessário possuir a funcionalidade
 
 Para acessar o saldo e detalhes de uma subconta, você utiliza o _endpoint_ `/api/v1/subaccount/{ID}` da API.
 
-Você pode acessar [aqui]([https://developers.woovi.com.br/api#tag/sub-account-(request-access)/paths/~1api~1v1~1subaccount~1%7Bid%7D/get](https://developers.woovi.com.br/api#tag/sub-account-(request-access)/paths/~1api~1v1~1subaccount~1%7Bid%7D/get))
+Você pode acessar [aqui](https://developers.woovi.com.br/api#tag/sub-account-(request-access)/paths/~1api~1v1~1subaccount~1%7Bid%7D/get)
 a documentação referente a esse _endpoint_.
 
 A chave pix registrada na subconta deve ser passada na url da requisição como parâmetro.

--- a/docs/subaccount/how-to-make-a-transfer-between-subaccounts.mdx
+++ b/docs/subaccount/how-to-make-a-transfer-between-subaccounts.mdx
@@ -16,7 +16,7 @@ Para a utilização desta funcionalidade é necessário possuir a funcionalidade
 
 Para realizar uma transferência entre subcontas da mesma empresa, você utiliza o _endpoint_ `/api/v1/subaccount/transfer` da API.
 
-Você pode acessar [aqui](<[https://developers.woovi.com.br/api#tag/sub-account-(request-access)/paths/~1api~1v1~1subaccount~1transfer/post](https://developers.woovi.com.br/api#tag/sub-account-(request-access)/paths/~1api~1v1~1subaccount~1transfer/post)>)
+Você pode acessar [aqui](https://developers.woovi.com.br/api#tag/sub-account-(request-access)/paths/~1api~1v1~1subaccount~1transfer/post)
 a documentação referente a esse _endpoint_.
 
 Os campos obrigatórios para fazer uma transferência entre subcontas são os seguintes:

--- a/docs/webhook/examples/account-register-approved-payload.mdx
+++ b/docs/webhook/examples/account-register-approved-payload.mdx
@@ -1,5 +1,5 @@
 ---
-id: wobhook-account-register-approved-payload
+id: webhook-account-register-approved-payload
 title: Payload de Registro Conta aprovado
 tags:
   - webhook

--- a/docs/webhook/seguranca/webhook-hmac.mdx
+++ b/docs/webhook/seguranca/webhook-hmac.mdx
@@ -113,7 +113,7 @@ defaultValue="PHP"
 :::info
 
 O campo `event` enviado junto ao payload do webhook tem seu valor conforme o tipo de evento que você escolheu no momento em que criou o webhook.
-Para saber mais sobre os tipos de eventos, acesse a [documentação de eventos](./webhook-events-type).
+Para saber mais sobre os tipos de eventos, acesse a [documentação de eventos](../webhook-events-type).
 
 :::
 

--- a/docs/webhook/webhook-events-type.md
+++ b/docs/webhook/webhook-events-type.md
@@ -87,7 +87,7 @@ Esse evento é enviado quando uma transação de reembolso é enviada mas é rej
 
 ## Eventos de Pagamento Instantâneo
 
-### OPENPIX:MOVEMENT_CONFIRMED
+### OPENPIX:MOVEMENT_CONFIRMED {#openpixmovement_confirmed}
 
 Esse evento é enviado quando um pagamento é confirmado.
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -156,7 +156,7 @@ const cards = [
     content: 'Criar cobranças Pix usando PHP',
     icon: <FaPhp color={'#787cb5'} size={30} />,
     docsTo:
-      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin.',
+      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin',
     to: 'https://app.woovi.com/home/applications/php/add',
   },
   {
@@ -164,7 +164,7 @@ const cards = [
     content: 'Criar cobranças Pix usando Shell',
     icon: <TbBrandPowershell color={'#787cb5'} size={30} />,
     docsTo:
-      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin.',
+      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin',
     to: 'https://app.woovi.com/home/applications/shell/add',
   },
   {
@@ -172,7 +172,7 @@ const cards = [
     content: 'Criar cobranças Pix usando Nodejs',
     icon: <SiNodedotjs color={'#80bd41'} size={30} />,
     docsTo:
-      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin.',
+      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin',
     to: 'https://app.woovi.com/home/applications/nodejs/add',
   },
   {
@@ -180,7 +180,7 @@ const cards = [
     content: 'Criar cobranças Pix usando C#',
     icon: <TbBrandCSharp color={'#9b4f97'} size={30} />,
     docsTo:
-      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin.',
+      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin',
     to: 'https://app.woovi.com/home/applications/csharp/add',
   },
   {
@@ -188,7 +188,7 @@ const cards = [
     content: 'Criar cobranças Pix usando Java',
     icon: <FaJava color={'#000000de'} size={30} />,
     docsTo:
-      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin.',
+      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin',
     to: 'https://app.woovi.com/home/applications/java/add',
   },
   {
@@ -196,7 +196,7 @@ const cards = [
     content: 'Criar cobranças Pix usando Python',
     icon: <FaPython size={30} />,
     docsTo:
-      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin.',
+      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin',
     to: 'https://app.woovi.com/home/applications/python/add',
   },
   {
@@ -204,7 +204,7 @@ const cards = [
     content: 'Criar cobranças Pix usando Delphi',
     icon: <SiDelphi color={'#f42736'} size={30} />,
     docsTo:
-      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin.',
+      '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin',
     to: 'https://app.woovi.com/home/applications/delphi/add',
   },
   {

--- a/src/swaggers/woovi.json
+++ b/src/swaggers/woovi.json
@@ -305,7 +305,117 @@
         ]
       }
     },
-    "/api/v1/account/": {
+    "/api/v1/account": {
+      "post": {
+        "tags": [
+          "account"
+        ],
+        "summary": "Duplicates the Account",
+        "description": "Duplicates the account associated with the authorization appId. Requires the bank account feature to be enabled.",
+        "x-required-scope": "ACCOUNT_POST",
+        "security": [
+          {
+            "AppID": [
+              "ACCOUNT_POST"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The created Account information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "account": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/CompanyBankAccount"
+                    }
+                  }
+                },
+                "example": {
+                  "account": {
+                    "accountId": "6290ccfd42831958a405debc",
+                    "isDefault": true,
+                    "balance": {
+                      "total": 129430,
+                      "blocked": 0,
+                      "available": 129430
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "An error message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "error": "Bank account feature is not enabled"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - Wrong API type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "error": "Wrong API type"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "Node + Native",
+            "source": "const http = require('https');\n\nconst options = {\n  method: 'POST',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/account',\n  headers: {\n    Authorization: '{APP_ID}'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.end();"
+          },
+          {
+            "lang": "Shell + Curl",
+            "source": "curl --request POST \\\n  --url https://api.woovi.com/api/v1/account \\\n  --header 'Authorization: {APP_ID}'"
+          },
+          {
+            "lang": "Php + Curl",
+            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/account\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"POST\",\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: {APP_ID}\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
+          },
+          {
+            "lang": "Python + Python3",
+            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\nheaders = { 'Authorization': \"{APP_ID}\" }\n\nconn.request(\"POST\", \"/api/v1/account\", headers=headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
+          },
+          {
+            "lang": "Go + Native",
+            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/account\"\n\n\treq, _ := http.NewRequest(\"POST\", url, nil)\n\n\treq.Header.Add(\"Authorization\", \"{APP_ID}\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          },
+          {
+            "lang": "Java + Okhttp",
+            "source": "OkHttpClient client = new OkHttpClient();\n\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/account\")\n  .post(null)\n  .addHeader(\"Authorization\", \"{APP_ID}\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
+          },
+          {
+            "lang": "Ruby + Native",
+            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/account\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\n\nresponse = http.request(request)\nputs response.read_body"
+          }
+        ]
+      },
       "get": {
         "tags": [
           "account"
@@ -482,118 +592,6 @@
         ]
       }
     },
-    "/api/v1/account": {
-      "post": {
-        "tags": [
-          "account"
-        ],
-        "summary": "Duplicates the Account",
-        "description": "Duplicates the account associated with the authorization appId. Requires the bank account feature to be enabled.",
-        "x-required-scope": "ACCOUNT_POST",
-        "security": [
-          {
-            "AppID": [
-              "ACCOUNT_POST"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The created Account information",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "account": {
-                      "type": "object",
-                      "$ref": "#/components/schemas/CompanyBankAccount"
-                    }
-                  }
-                },
-                "example": {
-                  "account": {
-                    "accountId": "6290ccfd42831958a405debc",
-                    "isDefault": true,
-                    "balance": {
-                      "total": 129430,
-                      "blocked": 0,
-                      "available": 129430
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "An error message",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "example": {
-                  "error": "Bank account feature is not enabled"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden - Wrong API type",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "example": {
-                  "error": "Wrong API type"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "Node + Native",
-            "source": "const http = require('https');\n\nconst options = {\n  method: 'POST',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/account',\n  headers: {\n    Authorization: '{APP_ID}'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.end();"
-          },
-          {
-            "lang": "Shell + Curl",
-            "source": "curl --request POST \\\n  --url https://api.woovi.com/api/v1/account \\\n  --header 'Authorization: {APP_ID}'"
-          },
-          {
-            "lang": "Php + Curl",
-            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/account\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"POST\",\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: {APP_ID}\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
-          },
-          {
-            "lang": "Python + Python3",
-            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\nheaders = { 'Authorization': \"{APP_ID}\" }\n\nconn.request(\"POST\", \"/api/v1/account\", headers=headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
-          },
-          {
-            "lang": "Go + Native",
-            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/account\"\n\n\treq, _ := http.NewRequest(\"POST\", url, nil)\n\n\treq.Header.Add(\"Authorization\", \"{APP_ID}\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
-          },
-          {
-            "lang": "Java + Okhttp",
-            "source": "OkHttpClient client = new OkHttpClient();\n\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/account\")\n  .post(null)\n  .addHeader(\"Authorization\", \"{APP_ID}\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
-          },
-          {
-            "lang": "Ruby + Native",
-            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/account\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\n\nresponse = http.request(request)\nputs response.read_body"
-          }
-        ]
-      }
-    },
     "/api/v1/account-register/{id}": {
       "delete": {
         "tags": [
@@ -611,10 +609,10 @@
         ],
         "parameters": [
           {
-            "name": "correlationID",
+            "name": "id",
             "in": "path",
             "required": true,
-            "description": "CorrelationID of the account register to delete",
+            "description": "Mongo _id or correlationID of the account register to delete",
             "schema": {
               "type": "string",
               "minLength": 1
@@ -726,15 +724,13 @@
           }
         },
         "x-codeSamples": []
-      }
-    },
-    "/api/v1/account-register": {
+      },
       "get": {
         "tags": [
           "account register"
         ],
-        "summary": "Get account register by CorrelationID",
-        "description": "Retrieves an existing account registration by CorrelationID",
+        "summary": "Get account register by id",
+        "description": "Retrieves an existing account registration by its Mongo _id, taxId or correlationID.",
         "x-required-scope": "ACCOUNT_REGISTER_GET",
         "security": [
           {
@@ -745,10 +741,10 @@
         ],
         "parameters": [
           {
-            "name": "CorrelationID",
+            "name": "id",
             "in": "path",
             "required": true,
-            "description": "CorrelationID of the account register",
+            "description": "Mongo _id, taxId or correlationID of the account register",
             "schema": {
               "type": "string",
               "example": "6fe18d8e-5009-4f57-8f1d-5b084b6b83ac"
@@ -4898,6 +4894,147 @@
             "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Get.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\n\nresponse = http.request(request)\nputs response.read_body"
           }
         ]
+      },
+      "patch": {
+        "tags": [
+          "customer"
+        ],
+        "summary": "Update a Customer",
+        "x-required-scope": "CUSTOMER_PATCH",
+        "security": [
+          {
+            "AppID": [
+              "CUSTOMER_PATCH"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Customer id or correlationID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "correlationID": {
+                "value": "fe7834b4060c488a9b0f89811be5f5cf"
+              }
+            }
+          }
+        ],
+        "description": "Endpoint to update a Customer",
+        "requestBody": {
+          "description": "Data to update a existent customer",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "$ref": "#/components/schemas/CustomerPatchPayload"
+              },
+              "example": {
+                "name": "Dan",
+                "email": "email0@example.com",
+                "phone": "5511999999999",
+                "address": {
+                  "zipcode": "30421322",
+                  "street": "Street",
+                  "number": "100",
+                  "neighborhood": "Neighborhood",
+                  "city": "Belo Horizonte",
+                  "state": "MG",
+                  "complement": "APTO",
+                  "country": "BR"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Customer ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "customer": {
+                      "$ref": "#/components/schemas/Customer"
+                    }
+                  },
+                  "example": {
+                    "customer": {
+                      "name": "Dan",
+                      "email": "email0@example.com",
+                      "phone": "5511999999999",
+                      "taxID": {
+                        "taxID": "31324227036",
+                        "type": "BR:CPF"
+                      },
+                      "address": {
+                        "zipcode": "30421322",
+                        "street": "Street",
+                        "number": "100",
+                        "neighborhood": "Neighborhood",
+                        "city": "Belo Horizonte",
+                        "state": "MG",
+                        "complement": "APTO",
+                        "country": "BR"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "An error message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "Node + Native",
+            "source": "const http = require('https');\n\nconst options = {\n  method: 'PATCH',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf',\n  headers: {\n    Authorization: '{APP_ID}',\n    'content-type': 'application/json'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.write(JSON.stringify({\n  name: 'string',\n  email: 'string',\n  phone: 'string',\n  taxID: 'string',\n  address: {\n    zipcode: 'string',\n    street: 'string',\n    number: 'string',\n    neighborhood: 'string',\n    city: 'string',\n    state: 'string',\n    complement: 'string',\n    country: 'string'\n  }\n}));\nreq.end();"
+          },
+          {
+            "lang": "Shell + Curl",
+            "source": "curl --request PATCH \\\n  --url https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf \\\n  --header 'Authorization: {APP_ID}' \\\n  --header 'content-type: application/json' \\\n  --data '{\"name\":\"string\",\"email\":\"string\",\"phone\":\"string\",\"taxID\":\"string\",\"address\":{\"zipcode\":\"string\",\"street\":\"string\",\"number\":\"string\",\"neighborhood\":\"string\",\"city\":\"string\",\"state\":\"string\",\"complement\":\"string\",\"country\":\"string\"}}'"
+          },
+          {
+            "lang": "Php + Curl",
+            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"PATCH\",\n  CURLOPT_POSTFIELDS => json_encode([\n    'name' => 'string',\n    'email' => 'string',\n    'phone' => 'string',\n    'taxID' => 'string',\n    'address' => [\n        'zipcode' => 'string',\n        'street' => 'string',\n        'number' => 'string',\n        'neighborhood' => 'string',\n        'city' => 'string',\n        'state' => 'string',\n        'complement' => 'string',\n        'country' => 'string'\n    ]\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: {APP_ID}\",\n    \"content-type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
+          },
+          {
+            "lang": "Python + Python3",
+            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\npayload = \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\"\n\nheaders = {\n    'Authorization': \"{APP_ID}\",\n    'content-type': \"application/json\"\n}\n\nconn.request(\"PATCH\", \"/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\", payload, headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
+          },
+          {
+            "lang": "Go + Native",
+            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\"\n\n\tpayload := strings.NewReader(\"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\")\n\n\treq, _ := http.NewRequest(\"PATCH\", url, payload)\n\n\treq.Header.Add(\"Authorization\", \"{APP_ID}\")\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          },
+          {
+            "lang": "Java + Okhttp",
+            "source": "OkHttpClient client = new OkHttpClient();\n\nMediaType mediaType = MediaType.parse(\"application/json\");\nRequestBody body = RequestBody.create(mediaType, \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\");\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\")\n  .patch(body)\n  .addHeader(\"Authorization\", \"{APP_ID}\")\n  .addHeader(\"content-type\", \"application/json\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
+          },
+          {
+            "lang": "Ruby + Native",
+            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Patch.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\nrequest[\"content-type\"] = 'application/json'\nrequest.body = \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\"\n\nresponse = http.request(request)\nputs response.read_body"
+          }
+        ]
       }
     },
     "/api/v1/customer": {
@@ -5162,149 +5299,6 @@
           {
             "lang": "Ruby + Native",
             "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/customer\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\nrequest[\"content-type\"] = 'application/json'\nrequest.body = \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"correlationID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\"\n\nresponse = http.request(request)\nputs response.read_body"
-          }
-        ]
-      }
-    },
-    "/api/v1/customer/{correlationID}": {
-      "patch": {
-        "tags": [
-          "customer"
-        ],
-        "summary": "Update a Customer",
-        "x-required-scope": "CUSTOMER_PATCH",
-        "security": [
-          {
-            "AppID": [
-              "CUSTOMER_PATCH"
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "correlationID",
-            "in": "path",
-            "description": "correlation ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "examples": {
-              "correlationID": {
-                "value": "fe7834b4060c488a9b0f89811be5f5cf"
-              }
-            }
-          }
-        ],
-        "description": "Endpoint to update a Customer",
-        "requestBody": {
-          "description": "Data to update a existent customer",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "$ref": "#/components/schemas/CustomerPatchPayload"
-              },
-              "example": {
-                "name": "Dan",
-                "email": "email0@example.com",
-                "phone": "5511999999999",
-                "address": {
-                  "zipcode": "30421322",
-                  "street": "Street",
-                  "number": "100",
-                  "neighborhood": "Neighborhood",
-                  "city": "Belo Horizonte",
-                  "state": "MG",
-                  "complement": "APTO",
-                  "country": "BR"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Customer ID",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "customer": {
-                      "$ref": "#/components/schemas/Customer"
-                    }
-                  },
-                  "example": {
-                    "customer": {
-                      "name": "Dan",
-                      "email": "email0@example.com",
-                      "phone": "5511999999999",
-                      "taxID": {
-                        "taxID": "31324227036",
-                        "type": "BR:CPF"
-                      },
-                      "address": {
-                        "zipcode": "30421322",
-                        "street": "Street",
-                        "number": "100",
-                        "neighborhood": "Neighborhood",
-                        "city": "Belo Horizonte",
-                        "state": "MG",
-                        "complement": "APTO",
-                        "country": "BR"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "An error message",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "Node + Native",
-            "source": "const http = require('https');\n\nconst options = {\n  method: 'PATCH',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf',\n  headers: {\n    Authorization: '{APP_ID}',\n    'content-type': 'application/json'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.write(JSON.stringify({\n  name: 'string',\n  email: 'string',\n  phone: 'string',\n  taxID: 'string',\n  address: {\n    zipcode: 'string',\n    street: 'string',\n    number: 'string',\n    neighborhood: 'string',\n    city: 'string',\n    state: 'string',\n    complement: 'string',\n    country: 'string'\n  }\n}));\nreq.end();"
-          },
-          {
-            "lang": "Shell + Curl",
-            "source": "curl --request PATCH \\\n  --url https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf \\\n  --header 'Authorization: {APP_ID}' \\\n  --header 'content-type: application/json' \\\n  --data '{\"name\":\"string\",\"email\":\"string\",\"phone\":\"string\",\"taxID\":\"string\",\"address\":{\"zipcode\":\"string\",\"street\":\"string\",\"number\":\"string\",\"neighborhood\":\"string\",\"city\":\"string\",\"state\":\"string\",\"complement\":\"string\",\"country\":\"string\"}}'"
-          },
-          {
-            "lang": "Php + Curl",
-            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"PATCH\",\n  CURLOPT_POSTFIELDS => json_encode([\n    'name' => 'string',\n    'email' => 'string',\n    'phone' => 'string',\n    'taxID' => 'string',\n    'address' => [\n        'zipcode' => 'string',\n        'street' => 'string',\n        'number' => 'string',\n        'neighborhood' => 'string',\n        'city' => 'string',\n        'state' => 'string',\n        'complement' => 'string',\n        'country' => 'string'\n    ]\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: {APP_ID}\",\n    \"content-type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
-          },
-          {
-            "lang": "Python + Python3",
-            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\npayload = \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\"\n\nheaders = {\n    'Authorization': \"{APP_ID}\",\n    'content-type': \"application/json\"\n}\n\nconn.request(\"PATCH\", \"/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\", payload, headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
-          },
-          {
-            "lang": "Go + Native",
-            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\"\n\n\tpayload := strings.NewReader(\"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\")\n\n\treq, _ := http.NewRequest(\"PATCH\", url, payload)\n\n\treq.Header.Add(\"Authorization\", \"{APP_ID}\")\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
-          },
-          {
-            "lang": "Java + Okhttp",
-            "source": "OkHttpClient client = new OkHttpClient();\n\nMediaType mediaType = MediaType.parse(\"application/json\");\nRequestBody body = RequestBody.create(mediaType, \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\");\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\")\n  .patch(body)\n  .addHeader(\"Authorization\", \"{APP_ID}\")\n  .addHeader(\"content-type\", \"application/json\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
-          },
-          {
-            "lang": "Ruby + Native",
-            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Patch.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\nrequest[\"content-type\"] = 'application/json'\nrequest.body = \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\"\n\nresponse = http.request(request)\nputs response.read_body"
           }
         ]
       }
@@ -16662,7 +16656,8 @@
                   "200": {
                     "description": "Notificação recebida com sucesso"
                   }
-                }
+                },
+                "summary": "Webhook: Pix received (charge paid)"
               }
             }
           },
@@ -16763,7 +16758,8 @@
                   "200": {
                     "description": "Notificação recebida com sucesso"
                   }
-                }
+                },
+                "summary": "Webhook: Pix received (detached / no charge)"
               }
             }
           },
@@ -16871,7 +16867,8 @@
                   "200": {
                     "description": "Notificação recebida com sucesso"
                   }
-                }
+                },
+                "summary": "Webhook: Pix received via static QR Code"
               }
             }
           }

--- a/static/swaggers/woovi.json
+++ b/static/swaggers/woovi.json
@@ -305,7 +305,117 @@
         ]
       }
     },
-    "/api/v1/account/": {
+    "/api/v1/account": {
+      "post": {
+        "tags": [
+          "account"
+        ],
+        "summary": "Duplicates the Account",
+        "description": "Duplicates the account associated with the authorization appId. Requires the bank account feature to be enabled.",
+        "x-required-scope": "ACCOUNT_POST",
+        "security": [
+          {
+            "AppID": [
+              "ACCOUNT_POST"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The created Account information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "account": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/CompanyBankAccount"
+                    }
+                  }
+                },
+                "example": {
+                  "account": {
+                    "accountId": "6290ccfd42831958a405debc",
+                    "isDefault": true,
+                    "balance": {
+                      "total": 129430,
+                      "blocked": 0,
+                      "available": 129430
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "An error message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "error": "Bank account feature is not enabled"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - Wrong API type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "error": "Wrong API type"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "Node + Native",
+            "source": "const http = require('https');\n\nconst options = {\n  method: 'POST',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/account',\n  headers: {\n    Authorization: '{APP_ID}'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.end();"
+          },
+          {
+            "lang": "Shell + Curl",
+            "source": "curl --request POST \\\n  --url https://api.woovi.com/api/v1/account \\\n  --header 'Authorization: {APP_ID}'"
+          },
+          {
+            "lang": "Php + Curl",
+            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/account\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"POST\",\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: {APP_ID}\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
+          },
+          {
+            "lang": "Python + Python3",
+            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\nheaders = { 'Authorization': \"{APP_ID}\" }\n\nconn.request(\"POST\", \"/api/v1/account\", headers=headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
+          },
+          {
+            "lang": "Go + Native",
+            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/account\"\n\n\treq, _ := http.NewRequest(\"POST\", url, nil)\n\n\treq.Header.Add(\"Authorization\", \"{APP_ID}\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          },
+          {
+            "lang": "Java + Okhttp",
+            "source": "OkHttpClient client = new OkHttpClient();\n\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/account\")\n  .post(null)\n  .addHeader(\"Authorization\", \"{APP_ID}\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
+          },
+          {
+            "lang": "Ruby + Native",
+            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/account\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\n\nresponse = http.request(request)\nputs response.read_body"
+          }
+        ]
+      },
       "get": {
         "tags": [
           "account"
@@ -482,118 +592,6 @@
         ]
       }
     },
-    "/api/v1/account": {
-      "post": {
-        "tags": [
-          "account"
-        ],
-        "summary": "Duplicates the Account",
-        "description": "Duplicates the account associated with the authorization appId. Requires the bank account feature to be enabled.",
-        "x-required-scope": "ACCOUNT_POST",
-        "security": [
-          {
-            "AppID": [
-              "ACCOUNT_POST"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The created Account information",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "account": {
-                      "type": "object",
-                      "$ref": "#/components/schemas/CompanyBankAccount"
-                    }
-                  }
-                },
-                "example": {
-                  "account": {
-                    "accountId": "6290ccfd42831958a405debc",
-                    "isDefault": true,
-                    "balance": {
-                      "total": 129430,
-                      "blocked": 0,
-                      "available": 129430
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "An error message",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "example": {
-                  "error": "Bank account feature is not enabled"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden - Wrong API type",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "example": {
-                  "error": "Wrong API type"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "Node + Native",
-            "source": "const http = require('https');\n\nconst options = {\n  method: 'POST',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/account',\n  headers: {\n    Authorization: '{APP_ID}'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.end();"
-          },
-          {
-            "lang": "Shell + Curl",
-            "source": "curl --request POST \\\n  --url https://api.woovi.com/api/v1/account \\\n  --header 'Authorization: {APP_ID}'"
-          },
-          {
-            "lang": "Php + Curl",
-            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/account\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"POST\",\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: {APP_ID}\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
-          },
-          {
-            "lang": "Python + Python3",
-            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\nheaders = { 'Authorization': \"{APP_ID}\" }\n\nconn.request(\"POST\", \"/api/v1/account\", headers=headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
-          },
-          {
-            "lang": "Go + Native",
-            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/account\"\n\n\treq, _ := http.NewRequest(\"POST\", url, nil)\n\n\treq.Header.Add(\"Authorization\", \"{APP_ID}\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
-          },
-          {
-            "lang": "Java + Okhttp",
-            "source": "OkHttpClient client = new OkHttpClient();\n\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/account\")\n  .post(null)\n  .addHeader(\"Authorization\", \"{APP_ID}\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
-          },
-          {
-            "lang": "Ruby + Native",
-            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/account\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\n\nresponse = http.request(request)\nputs response.read_body"
-          }
-        ]
-      }
-    },
     "/api/v1/account-register/{id}": {
       "delete": {
         "tags": [
@@ -611,10 +609,10 @@
         ],
         "parameters": [
           {
-            "name": "correlationID",
+            "name": "id",
             "in": "path",
             "required": true,
-            "description": "CorrelationID of the account register to delete",
+            "description": "Mongo _id or correlationID of the account register to delete",
             "schema": {
               "type": "string",
               "minLength": 1
@@ -726,15 +724,13 @@
           }
         },
         "x-codeSamples": []
-      }
-    },
-    "/api/v1/account-register": {
+      },
       "get": {
         "tags": [
           "account register"
         ],
-        "summary": "Get account register by CorrelationID",
-        "description": "Retrieves an existing account registration by CorrelationID",
+        "summary": "Get account register by id",
+        "description": "Retrieves an existing account registration by its Mongo _id, taxId or correlationID.",
         "x-required-scope": "ACCOUNT_REGISTER_GET",
         "security": [
           {
@@ -745,10 +741,10 @@
         ],
         "parameters": [
           {
-            "name": "CorrelationID",
+            "name": "id",
             "in": "path",
             "required": true,
-            "description": "CorrelationID of the account register",
+            "description": "Mongo _id, taxId or correlationID of the account register",
             "schema": {
               "type": "string",
               "example": "6fe18d8e-5009-4f57-8f1d-5b084b6b83ac"
@@ -4898,6 +4894,147 @@
             "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Get.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\n\nresponse = http.request(request)\nputs response.read_body"
           }
         ]
+      },
+      "patch": {
+        "tags": [
+          "customer"
+        ],
+        "summary": "Update a Customer",
+        "x-required-scope": "CUSTOMER_PATCH",
+        "security": [
+          {
+            "AppID": [
+              "CUSTOMER_PATCH"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Customer id or correlationID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "correlationID": {
+                "value": "fe7834b4060c488a9b0f89811be5f5cf"
+              }
+            }
+          }
+        ],
+        "description": "Endpoint to update a Customer",
+        "requestBody": {
+          "description": "Data to update a existent customer",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "$ref": "#/components/schemas/CustomerPatchPayload"
+              },
+              "example": {
+                "name": "Dan",
+                "email": "email0@example.com",
+                "phone": "5511999999999",
+                "address": {
+                  "zipcode": "30421322",
+                  "street": "Street",
+                  "number": "100",
+                  "neighborhood": "Neighborhood",
+                  "city": "Belo Horizonte",
+                  "state": "MG",
+                  "complement": "APTO",
+                  "country": "BR"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Customer ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "customer": {
+                      "$ref": "#/components/schemas/Customer"
+                    }
+                  },
+                  "example": {
+                    "customer": {
+                      "name": "Dan",
+                      "email": "email0@example.com",
+                      "phone": "5511999999999",
+                      "taxID": {
+                        "taxID": "31324227036",
+                        "type": "BR:CPF"
+                      },
+                      "address": {
+                        "zipcode": "30421322",
+                        "street": "Street",
+                        "number": "100",
+                        "neighborhood": "Neighborhood",
+                        "city": "Belo Horizonte",
+                        "state": "MG",
+                        "complement": "APTO",
+                        "country": "BR"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "An error message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "Node + Native",
+            "source": "const http = require('https');\n\nconst options = {\n  method: 'PATCH',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf',\n  headers: {\n    Authorization: '{APP_ID}',\n    'content-type': 'application/json'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.write(JSON.stringify({\n  name: 'string',\n  email: 'string',\n  phone: 'string',\n  taxID: 'string',\n  address: {\n    zipcode: 'string',\n    street: 'string',\n    number: 'string',\n    neighborhood: 'string',\n    city: 'string',\n    state: 'string',\n    complement: 'string',\n    country: 'string'\n  }\n}));\nreq.end();"
+          },
+          {
+            "lang": "Shell + Curl",
+            "source": "curl --request PATCH \\\n  --url https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf \\\n  --header 'Authorization: {APP_ID}' \\\n  --header 'content-type: application/json' \\\n  --data '{\"name\":\"string\",\"email\":\"string\",\"phone\":\"string\",\"taxID\":\"string\",\"address\":{\"zipcode\":\"string\",\"street\":\"string\",\"number\":\"string\",\"neighborhood\":\"string\",\"city\":\"string\",\"state\":\"string\",\"complement\":\"string\",\"country\":\"string\"}}'"
+          },
+          {
+            "lang": "Php + Curl",
+            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"PATCH\",\n  CURLOPT_POSTFIELDS => json_encode([\n    'name' => 'string',\n    'email' => 'string',\n    'phone' => 'string',\n    'taxID' => 'string',\n    'address' => [\n        'zipcode' => 'string',\n        'street' => 'string',\n        'number' => 'string',\n        'neighborhood' => 'string',\n        'city' => 'string',\n        'state' => 'string',\n        'complement' => 'string',\n        'country' => 'string'\n    ]\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: {APP_ID}\",\n    \"content-type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
+          },
+          {
+            "lang": "Python + Python3",
+            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\npayload = \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\"\n\nheaders = {\n    'Authorization': \"{APP_ID}\",\n    'content-type': \"application/json\"\n}\n\nconn.request(\"PATCH\", \"/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\", payload, headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
+          },
+          {
+            "lang": "Go + Native",
+            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\"\n\n\tpayload := strings.NewReader(\"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\")\n\n\treq, _ := http.NewRequest(\"PATCH\", url, payload)\n\n\treq.Header.Add(\"Authorization\", \"{APP_ID}\")\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          },
+          {
+            "lang": "Java + Okhttp",
+            "source": "OkHttpClient client = new OkHttpClient();\n\nMediaType mediaType = MediaType.parse(\"application/json\");\nRequestBody body = RequestBody.create(mediaType, \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\");\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\")\n  .patch(body)\n  .addHeader(\"Authorization\", \"{APP_ID}\")\n  .addHeader(\"content-type\", \"application/json\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
+          },
+          {
+            "lang": "Ruby + Native",
+            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Patch.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\nrequest[\"content-type\"] = 'application/json'\nrequest.body = \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\"\n\nresponse = http.request(request)\nputs response.read_body"
+          }
+        ]
       }
     },
     "/api/v1/customer": {
@@ -5162,149 +5299,6 @@
           {
             "lang": "Ruby + Native",
             "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/customer\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\nrequest[\"content-type\"] = 'application/json'\nrequest.body = \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"correlationID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\"\n\nresponse = http.request(request)\nputs response.read_body"
-          }
-        ]
-      }
-    },
-    "/api/v1/customer/{correlationID}": {
-      "patch": {
-        "tags": [
-          "customer"
-        ],
-        "summary": "Update a Customer",
-        "x-required-scope": "CUSTOMER_PATCH",
-        "security": [
-          {
-            "AppID": [
-              "CUSTOMER_PATCH"
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "correlationID",
-            "in": "path",
-            "description": "correlation ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "examples": {
-              "correlationID": {
-                "value": "fe7834b4060c488a9b0f89811be5f5cf"
-              }
-            }
-          }
-        ],
-        "description": "Endpoint to update a Customer",
-        "requestBody": {
-          "description": "Data to update a existent customer",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "$ref": "#/components/schemas/CustomerPatchPayload"
-              },
-              "example": {
-                "name": "Dan",
-                "email": "email0@example.com",
-                "phone": "5511999999999",
-                "address": {
-                  "zipcode": "30421322",
-                  "street": "Street",
-                  "number": "100",
-                  "neighborhood": "Neighborhood",
-                  "city": "Belo Horizonte",
-                  "state": "MG",
-                  "complement": "APTO",
-                  "country": "BR"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Customer ID",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "customer": {
-                      "$ref": "#/components/schemas/Customer"
-                    }
-                  },
-                  "example": {
-                    "customer": {
-                      "name": "Dan",
-                      "email": "email0@example.com",
-                      "phone": "5511999999999",
-                      "taxID": {
-                        "taxID": "31324227036",
-                        "type": "BR:CPF"
-                      },
-                      "address": {
-                        "zipcode": "30421322",
-                        "street": "Street",
-                        "number": "100",
-                        "neighborhood": "Neighborhood",
-                        "city": "Belo Horizonte",
-                        "state": "MG",
-                        "complement": "APTO",
-                        "country": "BR"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "An error message",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "Node + Native",
-            "source": "const http = require('https');\n\nconst options = {\n  method: 'PATCH',\n  hostname: 'api.woovi.com',\n  port: null,\n  path: '/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf',\n  headers: {\n    Authorization: '{APP_ID}',\n    'content-type': 'application/json'\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on('data', function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on('end', function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.write(JSON.stringify({\n  name: 'string',\n  email: 'string',\n  phone: 'string',\n  taxID: 'string',\n  address: {\n    zipcode: 'string',\n    street: 'string',\n    number: 'string',\n    neighborhood: 'string',\n    city: 'string',\n    state: 'string',\n    complement: 'string',\n    country: 'string'\n  }\n}));\nreq.end();"
-          },
-          {
-            "lang": "Shell + Curl",
-            "source": "curl --request PATCH \\\n  --url https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf \\\n  --header 'Authorization: {APP_ID}' \\\n  --header 'content-type: application/json' \\\n  --data '{\"name\":\"string\",\"email\":\"string\",\"phone\":\"string\",\"taxID\":\"string\",\"address\":{\"zipcode\":\"string\",\"street\":\"string\",\"number\":\"string\",\"neighborhood\":\"string\",\"city\":\"string\",\"state\":\"string\",\"complement\":\"string\",\"country\":\"string\"}}'"
-          },
-          {
-            "lang": "Php + Curl",
-            "source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"PATCH\",\n  CURLOPT_POSTFIELDS => json_encode([\n    'name' => 'string',\n    'email' => 'string',\n    'phone' => 'string',\n    'taxID' => 'string',\n    'address' => [\n        'zipcode' => 'string',\n        'street' => 'string',\n        'number' => 'string',\n        'neighborhood' => 'string',\n        'city' => 'string',\n        'state' => 'string',\n        'complement' => 'string',\n        'country' => 'string'\n    ]\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: {APP_ID}\",\n    \"content-type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
-          },
-          {
-            "lang": "Python + Python3",
-            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api.woovi.com\")\n\npayload = \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\"\n\nheaders = {\n    'Authorization': \"{APP_ID}\",\n    'content-type': \"application/json\"\n}\n\nconn.request(\"PATCH\", \"/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\", payload, headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
-          },
-          {
-            "lang": "Go + Native",
-            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io\"\n)\n\nfunc main() {\n\n\turl := \"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\"\n\n\tpayload := strings.NewReader(\"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\")\n\n\treq, _ := http.NewRequest(\"PATCH\", url, payload)\n\n\treq.Header.Add(\"Authorization\", \"{APP_ID}\")\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := io.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
-          },
-          {
-            "lang": "Java + Okhttp",
-            "source": "OkHttpClient client = new OkHttpClient();\n\nMediaType mediaType = MediaType.parse(\"application/json\");\nRequestBody body = RequestBody.create(mediaType, \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\");\nRequest request = new Request.Builder()\n  .url(\"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\")\n  .patch(body)\n  .addHeader(\"Authorization\", \"{APP_ID}\")\n  .addHeader(\"content-type\", \"application/json\")\n  .build();\n\nResponse response = client.newCall(request).execute();"
-          },
-          {
-            "lang": "Ruby + Native",
-            "source": "require 'uri'\nrequire 'net/http'\n\nurl = URI(\"https://api.woovi.com/api/v1/customer/fe7834b4060c488a9b0f89811be5f5cf\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\n\nrequest = Net::HTTP::Patch.new(url)\nrequest[\"Authorization\"] = '{APP_ID}'\nrequest[\"content-type\"] = 'application/json'\nrequest.body = \"{\\\"name\\\":\\\"string\\\",\\\"email\\\":\\\"string\\\",\\\"phone\\\":\\\"string\\\",\\\"taxID\\\":\\\"string\\\",\\\"address\\\":{\\\"zipcode\\\":\\\"string\\\",\\\"street\\\":\\\"string\\\",\\\"number\\\":\\\"string\\\",\\\"neighborhood\\\":\\\"string\\\",\\\"city\\\":\\\"string\\\",\\\"state\\\":\\\"string\\\",\\\"complement\\\":\\\"string\\\",\\\"country\\\":\\\"string\\\"}}\"\n\nresponse = http.request(request)\nputs response.read_body"
           }
         ]
       }
@@ -16662,7 +16656,8 @@
                   "200": {
                     "description": "Notificação recebida com sucesso"
                   }
-                }
+                },
+                "summary": "Webhook: Pix received (charge paid)"
               }
             }
           },
@@ -16763,7 +16758,8 @@
                   "200": {
                     "description": "Notificação recebida com sucesso"
                   }
-                }
+                },
+                "summary": "Webhook: Pix received (detached / no charge)"
               }
             }
           },
@@ -16871,7 +16867,8 @@
                   "200": {
                     "description": "Notificação recebida com sucesso"
                   }
-                }
+                },
+                "summary": "Webhook: Pix received via static QR Code"
               }
             }
           }


### PR DESCRIPTION
## O que

Corrige **7 erros de contrato OpenAPI** em `woovi.json` que estavam **vivos em `main`** (confirmado rodando `redocly lint` sobre `origin/main`). Cada correção foi **validada contra o código real** das rotas em `packages/openpix/src/api/openPixApiRouter.ts` e os handlers em `@woovi/accountregister`.

## Erros corrigidos

| Doc (errado) | Código (real) | Fix |
|---|---|---|
| `DELETE /api/v1/account-register/{id}` com path param `correlationID` | rota usa `:id` (handler lê `ctx.params.id`, resolve `_id`/taxId/correlationID) | param → `id` |
| `GET /api/v1/account-register` com path param `CorrelationID` fantasma (não existe na URL) | rota real é `GET /api/v1/account-register/:id` | movido p/ `/{id}`, param → `id` |
| `PATCH /api/v1/customer/{correlationID}` (colidia com `/customer/{id}` — diferia só no nome do param) | rota usa `:id` | mesclado em `/api/v1/customer/{id}` |
| `GET /api/v1/account/` (barra final) | rota é `/api/v1/account` sem barra | barra removida |
| 3 callbacks de webhook sem `summary` (`receivedPix`, `receivedPixDetached`, `receivedPixQrCode`) | — | summaries adicionados |

## Onde

Aplicado nos **dois** arquivos que a doc realmente usa:
- `src/swaggers/woovi.json` — fonte do build (redocusaurus)
- `static/swaggers/woovi.json` — servido em runtime em `/swaggers/woovi.json` (API Explorer / Scalar)

Eram idênticos e estavam dessincronizados só pelo estado; agora ambos batem.

## Validação

- Antes: `redocly lint` → **8 errors** (1 dos 8, o `post` duplicado em `/api/v1/stablecoin/subaccount`, só existia na branch `stablecoin-subaccount-create-endpoint`, não em `main` — não incluído aqui)
- Depois: **`redocly lint` → 0 errors** ✅ (restam 236 warnings de estilo, não bloqueantes) em ambos os arquivos
- Contagem de rotas 92 → 89: exatamente os 3 merges (nenhuma operação perdida — cada uma foi mesclada na rota canônica irmã)

## Fora de escopo (follow-ups)

- **`pixIndirect.json`** tem 6 erros próprios (`openapi`/`info`/`servers` mal posicionados, `requestBody`/`responses` mal aninhados, barra final em `/pix-charge/v1/emv/`). É **gerado** por `openapi-merge` de `pix-location`/`pix-charge` — precisa correção na fonte, não no arquivo merged. Vou abrir issue.
- Mirrors `woovi.yml` / `wooviPostman.json` estão defasados mas **não são consumidos pelo build**; regenerá-los produz ~4k linhas de ruído, então ficam fora deste PR.

---
🤖 Fix por Hermes (@hermesnous). Contratos validados contra o código-fonte real do router.
