### PR TITLE
docs(stablecoin): payout off-ramp flow (create/approve, BRL target)

### DIFF
--- a/docs/stablecoin/stablecoin-endpoints.md
+++ b/docs/stablecoin/stablecoin-endpoints.md
@@ -19,7 +19,7 @@ Todas as rotas ficam sob `/api/v1/stablecoin/` e exigem autenticação com o seu
 | `STABLECOIN_DEPOSIT_LIST` | `deposit/find`, `deposit` (listar) |
 | `STABLECOIN_SUBACCOUNT_CREATE` | `subaccount` (POST — solicitar KYB) |
 | `STABLECOIN_SUBACCOUNT_LIST` | `subaccount` (listar/detalhe), `wallets`, `subaccount/{id}/wallets`, `subaccount/{id}/balances` |
-| `STABLECOIN_PAYOUT_CREATE` | `payout/quote`, `payout` (criar/consultar) |
+| `STABLECOIN_PAYOUT_CREATE` | `payout/quote`, `payout` (criar/aprovar/consultar) |
 
 > A URL base de produção é `https://api.woovi.com`. Caso o App não tenha o escopo necessário, a resposta é `401` com `Application is missing required scope: ...`.
 
@@ -246,13 +246,13 @@ curl --request GET \
 
 GET `/api/v1/stablecoin/payout/quote`
 
-Cota a conversão do float INTERNAL para BRL via Pix. `value` é em **centavos do ativo** (ex.: `100` = 1,00 USDT).
+Cota um **Pix alvo em BRL**, debitando float INTERNAL. `value` é em **centavos de BRL** (ex.: `10000` = R$ 100,00). A resposta traz quanto de `currency` será debitado (`inputAmount`).
 
 Exige o escopo `STABLECOIN_PAYOUT_CREATE`.
 
 ```bash
 curl --request GET \
-  --url 'https://api.woovi.com/api/v1/stablecoin/payout/quote?value=100&currency=USDT' \
+  --url 'https://api.woovi.com/api/v1/stablecoin/payout/quote?value=10000&currency=USDT' \
   --header 'Authorization: <SEU_APP_ID>'
 ```
 
@@ -261,9 +261,9 @@ curl --request GET \
   "status": "ok",
   "quote": {
     "basePrice": 5.12,
-    "inputAmount": 1,
+    "inputAmount": 19.68,
     "inputCurrency": "USDT",
-    "outputAmount": 5.08,
+    "outputAmount": 100,
     "outputCurrency": "BRL",
     "pairName": "USDTBRL"
   }
@@ -274,14 +274,14 @@ curl --request GET \
 
 POST `/api/v1/stablecoin/payout`
 
-Gasta saldo INTERNAL (`USDT` | `USDC` | `BRLA`) e envia BRL para a `pixKey`. Consome o limite Woovi **OUT**. Não há passo de approve — o ticket do provedor é criado na hora.
+Cria o payout em `PENDING` (mesmo padrão do depósito): cota o **Pix alvo em BRL**, valida saldo INTERNAL, consome o limite **OUT** e resolve o beneficiário. O ticket do provedor **só é aberto no approve**.
 
 Exige o escopo `STABLECOIN_PAYOUT_CREATE`.
 
 | campo | tipo | obrigatório | descrição |
 | --- | --- | --- | --- |
-| `value` | number | sim | valor em **centavos** do ativo (ex.: `100000` = 1.000 USDC) |
-| `currency` | string | sim | `USDT` \| `USDC` \| `BRLA` |
+| `value` | number | sim | valor Pix alvo em **centavos de BRL** (ex.: `10000` = R$ 100,00) |
+| `currency` | string | sim | `USDT` \| `USDC` \| `BRLA` — ativo INTERNAL a debitar |
 | `pixKey` | string | sim | chave Pix de destino |
 | `correlationId` | string | não | idempotência |
 | `pixMessage` | string | não | mensagem Pix |
@@ -292,7 +292,7 @@ curl --request POST \
   --header 'Authorization: <SEU_APP_ID>' \
   --header 'content-type: application/json' \
   --data '{
-    "value": 100,
+    "value": 10000,
     "currency": "USDT",
     "pixKey": "thiago@entria.com.br",
     "correlationId": "payout-001"
@@ -301,7 +301,7 @@ curl --request POST \
 
 ```json
 {
-  "status": "PROCESSING",
+  "status": "PENDING",
   "payoutId": "6a721b1e3c785acfaebfa01c",
   "correlationId": "payout-001",
   "pixKey": "thiago@entria.com.br",
@@ -311,13 +311,35 @@ curl --request POST \
     "bankName": "SICOOB"
   },
   "quote": {
-    "inputAmount": 1,
+    "inputAmount": 19.68,
     "inputCurrency": "USDT",
-    "outputAmount": 5.08,
+    "outputAmount": 100,
     "outputCurrency": "BRL",
     "rate": 5.12,
     "fee": 0.04
   }
+}
+```
+
+### Aprovar um payout
+
+POST `/api/v1/stablecoin/payout/approve`
+
+Aprova um payout `PENDING` pelo `correlationId`, abre o ticket no provedor (debita INTERNAL e envia o Pix) e passa para `PROCESSING`.
+
+```bash
+curl --request POST \
+  --url https://api.woovi.com/api/v1/stablecoin/payout/approve \
+  --header 'Authorization: <SEU_APP_ID>' \
+  --header 'content-type: application/json' \
+  --data '{ "correlationId": "payout-001" }'
+```
+
+```json
+{
+  "status": "PROCESSING",
+  "correlationId": "payout-001",
+  "payoutId": "6a721b1e3c785acfaebfa01c"
 }
 ```
 
@@ -326,7 +348,7 @@ curl --request POST \
 - `GET /api/v1/stablecoin/payout/{payoutId}`
 - `GET /api/v1/stablecoin/payout?correlationId={correlationId}`
 
-Enquanto não estiver terminal, o status do ticket no provedor é relido (incluindo `PAID` → `COMPLETED`).
+Enquanto não estiver terminal e já existir ticket, o status no provedor é relido (incluindo `PAID` → `COMPLETED`).
 
 ### Solicitar uma subconta (KYB)
 

--- a/docs/stablecoin/stablecoin-fees.md
+++ b/docs/stablecoin/stablecoin-fees.md
@@ -1,6 +1,6 @@
 ---
 id: stablecoin-fees
-sidebar_position: 5
+sidebar_position: 6
 title: Taxas
 tags:
   - stablecoin

--- a/docs/stablecoin/stablecoin-flow.md
+++ b/docs/stablecoin/stablecoin-flow.md
@@ -1,7 +1,7 @@
 ---
 id: stablecoin-flow
 sidebar_position: 3
-title: Fluxo passo a passo
+title: Fluxo de depósito (on-ramp)
 tags:
   - stablecoin
   - api

--- a/docs/stablecoin/stablecoin-limits.md
+++ b/docs/stablecoin/stablecoin-limits.md
@@ -1,6 +1,6 @@
 ---
 id: stablecoin-limits
-sidebar_position: 6
+sidebar_position: 7
 title: Limites
 tags:
   - stablecoin

--- a/docs/stablecoin/stablecoin-payout-flow.md
+++ b/docs/stablecoin/stablecoin-payout-flow.md
@@ -1,0 +1,238 @@
+---
+id: stablecoin-payout-flow
+sidebar_position: 4
+title: Fluxo de payout (off-ramp)
+tags:
+  - stablecoin
+  - api
+  - payout
+---
+
+O fluxo de **payout** segue o mesmo padrão do [depósito](./stablecoin-flow.md): **criar** e depois **aprovar**. Você informa o **valor alvo em BRL**; na aprovação o float **INTERNAL** (USDT/USDC/BRLA) é debitado conforme a cotação e o Pix é enviado.
+
+Ativos suportados na saída: `USDT`, `USDC`, `BRLA`.
+
+## Fluxograma
+
+```mermaid
+sequenceDiagram
+    participant E as Sua Empresa
+    participant W as Woovi
+    participant C as Blockchain / custodiante
+    participant P as Pix
+    E->>W: GET /wallets
+    W-->>E: endereços INTERNAL (USDT/USDC/BRLA)
+    E->>C: Envia stablecoin on-chain para o endereço
+    C-->>W: Credita float INTERNAL
+    E->>W: GET /subaccount/{id}/balances (opcional)
+    W-->>E: saldo INTERNAL
+    E->>W: GET /payout/quote (opcional, value em centavos BRL)
+    W-->>E: Cotação (USDT a debitar, taxas)
+    E->>W: POST /payout (value = Pix alvo em centavos BRL)
+    Note over W: Quote BRL fixo · valida saldo · OUT limit · beneficiário
+    W-->>E: payoutId + status PENDING
+    E->>W: POST /payout/approve
+    Note over W: Abre ticket · debita INTERNAL · envia Pix
+    W-->>E: status PROCESSING
+    alt Sucesso
+        W->>P: Pix pago
+        W->>E: webhook STABLECOIN_PAYOUT_COMPLETED
+    else Falha
+        W->>E: webhook STABLECOIN_PAYOUT_FAILED
+    end
+```
+
+### Contas, float INTERNAL e limites
+
+Cada empresa (**CONTA PJ**) com KYB `CONFIRMED` tem uma **subconta** de stablecoin. O payout gasta apenas o saldo do float **INTERNAL** (endereços retornados por `GET /wallets`) — não o saldo da carteira smart wallet on-chain usada no depósito.
+
+O valor do payout consome o limite Woovi **OUT** da conta. Precisa de outra conta? Use o [**BaaS**](/docs/category/baas).
+
+```mermaid
+flowchart LR
+  A["Enviar USDT/USDC/BRLA<br/>para wallet INTERNAL"] --> B["Saldo INTERNAL"]
+  B --> C["POST /payout"]
+  C --> D["POST /payout/approve"]
+  D --> E["Pix na chave destino"]
+```
+
+## Pré-requisitos
+
+1. Subconta de stablecoin com status `CONFIRMED` (KYB aprovado). Veja [O que é o Stablecoin?](./stablecoin-what-is-it.md).
+2. App com o escopo `STABLECOIN_PAYOUT_CREATE` (criar/consultar payout). Para listar wallets e saldos, também `STABLECOIN_SUBACCOUNT_LIST`.
+3. **Saldo INTERNAL** suficiente no ativo que você vai gastar — financie os endereços de `GET /api/v1/stablecoin/wallets` antes.
+4. Limite **OUT** disponível na conta.
+5. Configure os [webhooks](./stablecoin-webhooks.md):
+   - `STABLECOIN_PAYOUT_COMPLETED`
+   - `STABLECOIN_PAYOUT_FAILED`
+
+## Passo a passo
+
+### 1. Obter as carteiras INTERNAL
+
+GET `/api/v1/stablecoin/wallets`
+
+Retorna os endereços custodiados ligados ao `companyBankAccount` do App. Envie USDT/USDC/BRLA on-chain para o endereço da rede/ativo desejado.
+
+```bash
+curl --request GET \
+  --url https://api.woovi.com/api/v1/stablecoin/wallets \
+  --header 'Authorization: <SEU_APP_ID>'
+```
+
+```json
+{
+  "status": "ok",
+  "companyBankAccountId": "682b62fe5afc2e15760223c5",
+  "subAccountId": "b3e144dd-7d10-457c-9b85-033085722ed1",
+  "wallets": [
+    { "address": "0xa5A558fedfCeFa9ac2751649Fa21CA0279F216Ce", "currency": "USDT", "network": "POLYGON" },
+    { "address": "TR54aGQPQghGDmHVuTQfSShP3ce8a6pCiT", "currency": "USDT", "network": "TRON" }
+  ]
+}
+```
+
+Guarde o `subAccountId` para consultar saldos.
+
+### 2. (Opcional) Conferir o saldo
+
+GET `/api/v1/stablecoin/subaccount/{subAccountId}/balances`
+
+Os saldos vêm na **unidade da moeda** (não em centavos). Faça poll após o envio on-chain até o crédito aparecer.
+
+```bash
+curl --request GET \
+  --url https://api.woovi.com/api/v1/stablecoin/subaccount/b3e144dd-7d10-457c-9b85-033085722ed1/balances \
+  --header 'Authorization: <SEU_APP_ID>'
+```
+
+```json
+{
+  "status": "ok",
+  "subAccountId": "b3e144dd-7d10-457c-9b85-033085722ed1",
+  "balances": { "USDT": 0.425458, "USDC": 0, "BRLA": 0 }
+}
+```
+
+### 3. (Opcional) Cotar o payout
+
+GET `/api/v1/stablecoin/payout/quote?value=10000&currency=USDT`
+
+`value` é o **Pix alvo em centavos de BRL** (ex.: `10000` = R$ 100,00). A resposta traz quanto de `currency` será debitado do float INTERNAL (`inputAmount`) e as taxas aplicadas.
+
+```bash
+curl --request GET \
+  --url 'https://api.woovi.com/api/v1/stablecoin/payout/quote?value=10000&currency=USDT' \
+  --header 'Authorization: <SEU_APP_ID>'
+```
+
+### 4. Criar o payout
+
+POST `/api/v1/stablecoin/payout`
+
+```json
+{
+  "value": 10000,
+  "currency": "USDT",
+  "pixKey": "thiago@entria.com.br",
+  "correlationId": "payout-001",
+  "pixMessage": "pagamento stablecoin"
+}
+```
+
+Na criação a Woovi: cota com BRL fixo → valida saldo INTERNAL → consome o limite **OUT** (em BRL) → resolve o beneficiário Pix → persiste como `PENDING`. O ticket **ainda não** é aberto.
+
+O `correlationId` é opcional e serve de **idempotência**: reutilizar o mesmo valor devolve o payout já criado.
+
+```bash
+curl --request POST \
+  --url https://api.woovi.com/api/v1/stablecoin/payout \
+  --header 'Authorization: <SEU_APP_ID>' \
+  --header 'content-type: application/json' \
+  --data '{
+    "value": 10000,
+    "currency": "USDT",
+    "pixKey": "thiago@entria.com.br",
+    "correlationId": "payout-001"
+  }'
+```
+
+```json
+{
+  "status": "PENDING",
+  "payoutId": "6a721b1e3c785acfaebfa01c",
+  "correlationId": "payout-001",
+  "pixKey": "thiago@entria.com.br",
+  "pixKeyOwner": {
+    "name": "Marshall Bilderback",
+    "taxId": "***.751.185-**",
+    "bankName": "SICOOB"
+  },
+  "quote": {
+    "inputAmount": 19.68,
+    "inputCurrency": "USDT",
+    "outputAmount": 100,
+    "outputCurrency": "BRL",
+    "rate": 5.12,
+    "fee": 0.04
+  }
+}
+```
+
+### 5. Aprovar o payout (enviar o Pix)
+
+POST `/api/v1/stablecoin/payout/approve`
+
+```json
+{ "correlationId": "payout-001" }
+```
+
+A aprovação abre o ticket no provedor (debita o float INTERNAL e envia o Pix). O status passa para `PROCESSING`.
+
+```bash
+curl --request POST \
+  --url https://api.woovi.com/api/v1/stablecoin/payout/approve \
+  --header 'Authorization: <SEU_APP_ID>' \
+  --header 'content-type: application/json' \
+  --data '{ "correlationId": "payout-001" }'
+```
+
+### 6. Acompanhar a conclusão
+
+Quando o Pix é pago, você recebe `STABLECOIN_PAYOUT_COMPLETED` (pode incluir `endToEndId`). Em falha, `STABLECOIN_PAYOUT_FAILED`. Detalhes em [Webhooks](./stablecoin-webhooks.md).
+
+Você também pode consultar a qualquer momento:
+
+- GET `/api/v1/stablecoin/payout/{payoutId}`
+- GET `/api/v1/stablecoin/payout?correlationId=payout-001`
+
+Enquanto o payout não estiver terminal, a consulta relê o ticket no provedor e atualiza o status (incluindo `PAID` → `COMPLETED`).
+
+## Estados do payout
+
+| Status | Significado |
+| --- | --- |
+| `PENDING` | Criado; aguardando aprovação |
+| `PROCESSING` | Aprovado; ticket / Pix em andamento |
+| `COMPLETED` | Pix pago com sucesso |
+| `FAILED` | Falhou em alguma etapa |
+
+```mermaid
+flowchart LR
+  PENDING --> PROCESSING --> COMPLETED
+  PENDING --> FAILED
+  PROCESSING --> FAILED
+```
+
+## Referência rápida
+
+| Etapa | Método | Rota | Escopo |
+| --- | --- | --- | --- |
+| Carteiras | GET | `/api/v1/stablecoin/wallets` | `STABLECOIN_SUBACCOUNT_LIST` |
+| Saldos | GET | `/api/v1/stablecoin/subaccount/{id}/balances` | `STABLECOIN_SUBACCOUNT_LIST` |
+| Cotação | GET | `/api/v1/stablecoin/payout/quote` | `STABLECOIN_PAYOUT_CREATE` |
+| Criar | POST | `/api/v1/stablecoin/payout` | `STABLECOIN_PAYOUT_CREATE` |
+| Aprovar | POST | `/api/v1/stablecoin/payout/approve` | `STABLECOIN_PAYOUT_CREATE` |
+| Consultar | GET | `/api/v1/stablecoin/payout/{payoutId}` | `STABLECOIN_PAYOUT_CREATE` |
+
+Detalhes dos payloads: [Endpoints](./stablecoin-endpoints.md).

--- a/docs/stablecoin/stablecoin-webhooks.md
+++ b/docs/stablecoin/stablecoin-webhooks.md
@@ -1,6 +1,6 @@
 ---
 id: stablecoin-webhooks
-sidebar_position: 4
+sidebar_position: 5
 title: Webhooks
 tags:
   - stablecoin

--- a/docs/stablecoin/stablecoin-what-is-it.md
+++ b/docs/stablecoin/stablecoin-what-is-it.md
@@ -51,6 +51,7 @@ Para iniciar o processo de KYB, entre em contato com o suporte.
 
 - [Endpoints](./stablecoin-endpoints.md) — todas as rotas da API
 - [Fluxo passo a passo](./stablecoin-flow.md) — do depósito à entrega on-chain
+- [Fluxo de payout (off-ramp)](./stablecoin-payout-flow.md) — do float INTERNAL ao Pix
 - [Webhooks](./stablecoin-webhooks.md) — como ser notificado
 - [Taxas](./stablecoin-fees.md)
 - [Limites](./stablecoin-limits.md)


### PR DESCRIPTION
## Summary
- New page `stablecoin-payout-flow`: fund INTERNAL → quote → create (`PENDING`) → approve → webhook/poll.
- Update endpoints docs for BRL-target `value` and `POST /payout/approve`.
- Sidebar: rename deposit flow to on-ramp; link payout flow from what-is-it.

## Test plan
- [ ] Preview Docusaurus sidebar under Stablecoin
- [ ] Confirm `/docs/stablecoin/stablecoin-payout-flow` renders mermaid + curls
- [ ] Cross-check against woovi-stablecoin payout create/approve PR once merged


Made with [Cursor](https://cursor.com)