### PR TITLE
docs(boleto): document the fine and interest the payer paid

### DIFF
--- a/docs/boleto/boleto-juros-multa-api.md
+++ b/docs/boleto/boleto-juros-multa-api.md
@@ -244,3 +244,63 @@ Na resposta da API, você encontrará o objeto `interestsSettings` que confirma 
 
 Este objeto confirma que os valores de juros e multa foram configurados corretamente. Os valores são retornados em basis points (100 = 1%).
 
+:::caution Isso é a regra, não o valor cobrado
+Os percentuais acima definem **como** os encargos são calculados. Quanto o pagador
+**efetivamente pagou** de multa e juros só existe depois do pagamento, e vem em
+outros campos — veja a seção abaixo.
+:::
+
+---
+
+## 4. Como saber quanto o pagador pagou de juros e multa
+
+Quando o boleto é pago depois do vencimento, o banco calcula os encargos e cobra
+um valor acima do emitido. A Woovi devolve essa diferença **discriminada**, em
+centavos:
+
+| Campo | Descrição |
+| --- | --- |
+| `finesValue` | Multa que o pagador pagou. |
+| `interestsValue` | Juros que o pagador pagou. |
+
+Cada campo é **omitido quando não houve**, então um boleto pago em dia não traz
+nenhum dos dois.
+
+### Como os valores se relacionam
+
+- `charge.value` — o valor **emitido** na cobrança
+- `boleto.value` — o que o pagador **efetivamente pagou**
+
+```
+boleto.value = charge.value + finesValue + interestsValue
+```
+
+Exemplo de um boleto emitido por R$ 2.428,98 e pago com atraso:
+
+```json
+{
+  "charge": { "value": 242898 },
+  "boleto": {
+    "value": 245000,
+    "finesValue": 1902,
+    "interestsValue": 200
+  }
+}
+```
+
+R$ 19,02 de multa e R$ 2,00 de juros, somando os R$ 21,02 pagos acima do emitido.
+
+### Onde esses campos aparecem
+
+| Onde | Quando usar |
+| --- | --- |
+| Webhook **`OPENPIX:CHARGE_COMPLETED`** | No momento do pagamento. Veja **[Webhook de Boleto pago](/docs/boleto/boleto-webhook)**. |
+| Webhook **`BOLETO_SETTLED`** | No momento em que o valor é creditado na sua conta. Veja **[Conciliação de liquidação](/docs/boleto/boleto-reconciliation)**. |
+| **`GET /api/v1/boleto-transaction`** | Para conciliar um período em lote, ou consultar uma transação pelo `boletoTransactionID`. |
+
+:::note
+Os valores são os **cobrados pelo banco**, não um recálculo a partir dos
+percentuais que você configurou. Use-os direto na conciliação, sem refazer a conta
+a partir da data de pagamento.
+:::
+

--- a/docs/boleto/boleto-reconciliation.md
+++ b/docs/boleto/boleto-reconciliation.md
@@ -188,7 +188,9 @@ acrescenta o **`boleto.settledAt`**:
     "boletoBarcode": "34191120100002428981103069645110772982609000",
     "boletoDigitable": "34191103036964511077129826090002112010000242898",
     "fee": 299,
-    "settledAt": "2026-07-27T10:00:00.000Z"
+    "settledAt": "2026-07-27T10:00:00.000Z",
+    "finesValue": 1902,
+    "interestsValue": 200
   }
 }
 ```
@@ -200,6 +202,14 @@ pagamento.
 `charge.value` é o valor **emitido**; `boleto.value` é o que o pagador
 **efetivamente pagou**, que fica acima do emitido quando o boleto é pago depois do
 vencimento (juros e multa). Concilie o crédito pelo `boleto.value`.
+
+A diferença entre os dois vem discriminada: **`finesValue`** é a multa e
+**`interestsValue`** o juros que o pagador pagou, em centavos, como cobrados pelo
+banco. No exemplo acima, `245000 - 242898 = 2102 = 1902 + 200`.
+
+Cada campo é **omitido quando não houve** — um boleto pago em dia não traz
+nenhum dos dois. Veja
+**[Boleto com Juros e Multa](/docs/boleto/boleto-juros-multa)**.
 :::
 
 Guarde o **`boletoTransactionID`**: é o id público da transação, e com ele você
@@ -239,6 +249,8 @@ curl --request GET \
       "fee": 299,
       "createdAt": "2026-07-26T13:04:11.212Z",
       "settledAt": "2026-07-27T10:00:00.000Z",
+      "finesValue": 1902,
+      "interestsValue": 200,
       "charge": {
         "value": 242898,
         "status": "COMPLETED",

--- a/docs/boleto/boleto-webhook.md
+++ b/docs/boleto/boleto-webhook.md
@@ -141,11 +141,33 @@ O corpo enviado para a sua URL tem o seguinte formato:
 | `boleto.boletoBarcode` | Código de barras do boleto. |
 | `boleto.boletoDigitable` | Linha digitável do boleto. |
 | `boleto.fee` | Taxa aplicada, em **centavos**. |
+| `boleto.finesValue` | Multa que o pagador pagou por atraso, em **centavos**. Ausente quando não houve. |
+| `boleto.interestsValue` | Juros que o pagador pagou por atraso, em **centavos**. Ausente quando não houve. |
 | `company` | Dados da sua empresa (`id`, `name`, `taxID`). |
 
 :::note
 Todos os valores monetários (`value`, `fee`, `valueWithDiscount`, ...) são
 expressos em **centavos** (`10000` = R$ 100,00).
+:::
+
+:::tip Boleto pago com atraso
+No exemplo acima o boleto foi pago em dia, então `charge.value` e `boleto.value`
+são iguais e não há multa nem juros. Quando o pagamento é feito depois do
+vencimento, `boleto.value` fica acima de `charge.value` e a diferença vem
+discriminada:
+
+```json
+"boleto": {
+  "value": 245000,
+  "finesValue": 1902,
+  "interestsValue": 200,
+  "...": "..."
+}
+```
+
+Aqui a cobrança foi emitida por `242898` e o pagador pagou `245000`: `1902` de
+multa e `200` de juros. Veja
+**[Boleto com Juros e Multa](/docs/boleto/boleto-juros-multa)**.
 :::
 
 ---


### PR DESCRIPTION
The **Boleto com Juros e Multa** page explained how to *configure* the charges and stopped at the settings the API echoes back — it never said how to learn what was actually charged. That is the question that reaches support: "I set 2% fine, where do I see what the customer paid?"

## What changes

**`boleto-juros-multa-api.md`** — new section on how to know how much the payer paid: the fields, the relation to the emitted and paid values, and where they arrive.

```
boleto.value = charge.value + finesValue + interestsValue
```

Plus a callout right after the settings section making clear those percentages are the **rule**, not the amount charged.

**`boleto-webhook.md`** — the fields in the paid-charge payload table, and a callout showing the shape of an overdue boleto (the page's main example is a boleto paid on time, so it carries neither field).

**`boleto-reconciliation.md`** — the fields in the `BOLETO_SETTLED` payload and in the `GET /api/v1/boleto-transaction` response, and the existing note about `boleto.value` being above `charge.value` now says how that difference breaks down.

## What is deliberately not documented

`discountValue` exists in the schema but never appears: Woovi issues boletos with no discount registered, so the amount is always zero and the field always absent. Documenting it in prose would have merchants expecting something that cannot happen.

## Timing

These fields ship with the code merged in [woovi#102429](https://github.com/entria/woovi/pull/102429). Worth merging once that is live in production, so the docs do not describe a response the API is not yet giving.

Related to https://github.com/entria/woovi-issues/issues/4242