### PR TITLE
docs(api): flag the Pix key check endpoints as request-access

### DIFF
--- a/src/swaggers/woovi.json
+++ b/src/swaggers/woovi.json
@@ -10915,10 +10915,10 @@
     "/api/v1/pix-keys/{pixKey}/check": {
       "get": {
         "tags": [
-          "pixKey"
+          "pixKey check (request access)"
         ],
         "summary": "Check data from a Pix key",
-        "description": "Get data from a Pix key if it exists",
+        "description": "Get data from a Pix key if it exists\n\n**This endpoint is not enabled by default.** It queries the DICT for the holder of a Pix key that is not yours, so it has to be requested from support and goes through an internal review before being turned on. Calls are billed per query.\n\nIf what you need is to confirm that an account belongs to who you expect, use bank data validation instead — it is available to every account with no approval:\n\n- [Validating bank data with a Pix key](https://developers.woovi.com/docs/flows/validate-bank-data)\n- [Validating bank data with branch and account number](https://developers.woovi.com/docs/flows/validate-bank-data-manual)\n",
         "parameters": [
           {
             "name": "pixKey",
@@ -11038,10 +11038,10 @@
     "/api/v1/pix-keys/check": {
       "post": {
         "tags": [
-          "pixKey"
+          "pixKey check (request access)"
         ],
         "summary": "Check data from a Pix key",
-        "description": "Get data from a Pix key if it exists",
+        "description": "Get data from a Pix key if it exists\n\n**This endpoint is not enabled by default.** It queries the DICT for the holder of a Pix key that is not yours, so it has to be requested from support and goes through an internal review before being turned on. Calls are billed per query.\n\nIf what you need is to confirm that an account belongs to who you expect, use bank data validation instead — it is available to every account with no approval:\n\n- [Validating bank data with a Pix key](https://developers.woovi.com/docs/flows/validate-bank-data)\n- [Validating bank data with branch and account number](https://developers.woovi.com/docs/flows/validate-bank-data-manual)\n",
         "requestBody": {
           "required": true,
           "content": {
@@ -22134,6 +22134,10 @@
     {
       "name": "pixKey",
       "description": "Endpoint to manage Pix Keys\n"
+    },
+    {
+      "name": "pixKey check (request access)",
+      "description": "Endpoints to look up the holder of a Pix key through the DICT.\n\n**This endpoint is not enabled by default.** It queries the DICT for the holder of a Pix key that is not yours, so it has to be requested from support and goes through an internal review before being turned on. Calls are billed per query.\n\nIf what you need is to confirm that an account belongs to who you expect, use bank data validation instead — it is available to every account with no approval:\n\n- [Validating bank data with a Pix key](https://developers.woovi.com/docs/flows/validate-bank-data)\n- [Validating bank data with branch and account number](https://developers.woovi.com/docs/flows/validate-bank-data-manual)\n"
     },
     {
       "name": "pixQrCode",


### PR DESCRIPTION
Requested by @Hofferman: mark the Pix key check endpoints as request-access in
the API reference, and warn on the GET and POST that the endpoint has to be
enabled by support, that it goes through an internal review, and that bank data
validation is the recommended alternative that needs no approval.

## What changed

The two endpoints that look up the holder of a Pix key sat under the plain
`pixKey` tag, so nothing in the reference said they have to be turned on first.
They now live under `pixKey check (request access)`, matching how `partner`,
`payment` and `transfer` are already marked, and both carry the warning:

> **This endpoint is not enabled by default.** It queries the DICT for the
> holder of a Pix key that is not yours, so it has to be requested from support
> and goes through an internal review before being turned on. Calls are billed
> per query.
>
> If what you need is to confirm that an account belongs to who you expect, use
> bank data validation instead — it is available to every account with no
> approval: [with a Pix key](https://developers.woovi.com/docs/flows/validate-bank-data)
> · [with branch and account number](https://developers.woovi.com/docs/flows/validate-bank-data-manual)

## Only the two check endpoints moved

The `pixKey` tag holds eight endpoints, and renaming the whole tag would have
marked six open ones as gated. Verified against a live account:

| endpoint | result |
|---|---|
| `GET /api/v1/pix-keys` | 200 — open |
| `GET /api/v1/pix-keys/tokens` | 200 — open |
| `GET /api/v1/pix-keys/tokens/logs` | 200 — open |
| `POST /api/v1/pix-keys/check` | passes the gate and queries the DICT |

The last one returns `404 "Chave Pix não encontrada"` on that account because it
has the paid feature enabled; an account without it gets
`403 "Sua conta não tem permissão para usar este endpoint"`.

So creating, listing and deleting your own keys and reading the token bucket
stay on `pixKey`. Only the DICT lookup is behind the gate — three checks in
`pixKeyCheckPost.ts`: the provider feature `PIX_KEY_CHECK`, the AppID scope, and
the company feature, which is billed.

**If you would rather have the badge on the whole `pixKey` tag as originally
asked, say so — it is a two-line change.**

## Note

The JSON round-trips byte-identical, so the 22k-line spec is not reformatted:
8 insertions, 4 deletions.

Unrelated and not touched here: `decode`, `statement` and `invoice` are used as
tags on operations but never declared in the `tags` block, so they render
without a description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H46kNup5AsHeupM9uRFwUQ