### PR TITLE
feat(home): WebGL hero and polished landing sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "1.2.0",
+    "@designcodeio/threeui": "^0.3.0",
     "@docusaurus/core": "3.10.1",
     "@docusaurus/faster": "3.10.1",
     "@docusaurus/plugin-client-redirects": "3.10.1",
@@ -32,6 +33,7 @@
     "redocusaurus": "2.5.0",
     "snippet-enricher-cli": "^0.0.8",
     "styled-components": "^6.4.1",
+    "three": "^0.185.1",
     "url": "^0.11.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@cmfcmf/docusaurus-search-local':
         specifier: 1.2.0
         version: 1.2.0(@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.18))(@mdx-js/react@3.1.1(@types/react@18.3.27)(react@18.3.1))(@rspack/core@1.7.11(@swc/helpers@0.5.18))(@swc/core@1.15.33(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(search-insights@2.17.3)
+      '@designcodeio/threeui':
+        specifier: ^0.3.0
+        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.185.1)
       '@docusaurus/core':
         specifier: 3.10.1
         version: 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.18))(@mdx-js/react@3.1.1(@types/react@18.3.27)(react@18.3.1))(@rspack/core@1.7.11(@swc/helpers@0.5.18))(@swc/core@1.15.33(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
@@ -101,6 +104,9 @@ importers:
       styled-components:
         specifier: ^6.4.1
         version: 6.4.1(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      three:
+        specifier: ^0.185.1
+        version: 0.185.1
       url:
         specifier: ^0.11.4
         version: 0.11.4
@@ -1291,6 +1297,13 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       postcss: ^8.4
+
+  '@designcodeio/threeui@0.3.0':
+    resolution: {integrity: sha512-i9H4Hxf5iGaPYFzAL1vvHc3NFWbutL3pXoj+IyI3DzMsaIkzhNaMeFX/sYdYiNDkGrBCc7Q0N4exr+7Uxm/SSQ==}
+    peerDependencies:
+      react: '>=18 <20'
+      react-dom: '>=18 <20'
+      three: '>=0.149 <1'
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -3261,6 +3274,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/dom@1.11.20':
     resolution: {integrity: sha512-jgfGYdOH+xHJF/j8gudjsYu3oIjFyXhCWcgKaw3vQnT616gSqyqnGQGOItL+BQtQZACKNISwIfx5PuOtztMKLA==}
@@ -3873,6 +3887,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -5204,6 +5219,7 @@ packages:
   eslint@9.37.0:
     resolution: {integrity: sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -9538,6 +9554,15 @@ packages:
     peerDependencies:
       tslib: ^2
 
+  three@0.128.0:
+    resolution: {integrity: sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA==}
+
+  three@0.165.0:
+    resolution: {integrity: sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA==}
+
+  three@0.185.1:
+    resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
+
   throttle-debounce@3.0.1:
     resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
     engines: {node: '>=10'}
@@ -11752,6 +11777,14 @@ snapshots:
   '@csstools/utilities@2.0.0(postcss@8.5.6)':
     dependencies:
       postcss: 8.5.6
+
+  '@designcodeio/threeui@0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.185.1)':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      three: 0.185.1
+      three128: three@0.128.0
+      three165: three@0.165.0
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -22875,6 +22908,12 @@ snapshots:
   thingies@2.5.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
+
+  three@0.128.0: {}
+
+  three@0.165.0: {}
+
+  three@0.185.1: {}
 
   throttle-debounce@3.0.1: {}
 

--- a/src/components/Card/card.module.css
+++ b/src/components/Card/card.module.css
@@ -1,9 +1,20 @@
 .card-link--item {
-  flex-grow: 1;
-  flex-basis: 300px;
-  background-color: rgba(198, 198, 198, 0.35);
+  border: 1px solid var(--ifm-color-emphasis-200);
   border-radius: 20px;
+  background-color: var(--ifm-background-surface-color);
   padding: 26px;
+  text-decoration: none;
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.card-link--item:hover {
+  transform: translateY(-3px);
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 22px 40px -26px rgba(0, 0, 0, 0.55);
+  text-decoration: none;
 }
 
 .card-link-div-icon {
@@ -12,7 +23,8 @@
   gap: 0.4rem;
 }
 
-.card-link--item > h3 {
+.card-link--item > h3,
+.card-link-div-icon > h3 {
   font-size: 20px;
   font-weight: 700;
 }
@@ -20,4 +32,10 @@
 .card-link--item > p {
   font-size: 16px;
   font-weight: 300;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-link--item:hover {
+    transform: none;
+  }
 }

--- a/src/components/Hero/CodeCard.tsx
+++ b/src/components/Hero/CodeCard.tsx
@@ -1,0 +1,169 @@
+import React, { useState } from 'react';
+import clsx from 'clsx';
+
+import styles from './Hero.module.css';
+
+type Language = 'bash' | 'json';
+
+type Snippet = {
+  id: string;
+  label: string;
+  language: Language;
+  file: string;
+  code: string;
+};
+
+// Minimal token colorizer, kept local so the hero card stays dark in both
+// themes instead of following the site's Prism theme.
+const PATTERNS: Record<Language, RegExp> = {
+  bash: /(?<comment>#[^\n]*)|(?<string>'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")|(?<url>https?:\/\/[^\s'"\\]+)|(?<flag>(?:^|\s)--?[A-Za-z][\w-]*)|(?<keyword>\bcurl\b)/gm,
+  json: /(?<key>"(?:[^"\\]|\\.)*"(?=\s*:))|(?<string>"(?:[^"\\]|\\.)*")|(?<number>-?\b\d+(?:\.\d+)?\b)|(?<literal>\b(?:true|false|null)\b)/g,
+};
+
+const highlight = (code: string, language: Language) => {
+  const pattern = new RegExp(PATTERNS[language]);
+  const nodes: React.ReactNode[] = [];
+
+  let lastIndex = 0;
+  let match: RegExpExecArray | null = null;
+
+  while ((match = pattern.exec(code)) !== null) {
+    const [text] = match;
+    const type = Object.keys(match.groups ?? {}).find(
+      (group) => match?.groups?.[group] !== undefined,
+    );
+
+    if (match.index > lastIndex) {
+      nodes.push(code.slice(lastIndex, match.index));
+    }
+
+    nodes.push(
+      <span key={`${type}-${match.index}`} className={styles[`token-${type}`]}>
+        {text}
+      </span>,
+    );
+
+    lastIndex = match.index + text.length;
+  }
+
+  nodes.push(code.slice(lastIndex));
+
+  return nodes;
+};
+
+const snippets: Snippet[] = [
+  {
+    id: 'charge',
+    label: 'Criar cobrança',
+    language: 'bash',
+    file: 'POST /api/v1/charge',
+    code: `curl -X POST https://api.woovi.com/api/v1/charge \\
+  -H 'Authorization: SEU_APP_ID' \\
+  -H 'Content-Type: application/json' \\
+  -d '{
+    "correlationID": "pedido-4321",
+    "value": 1990,
+    "comment": "Pedido #4321"
+  }'`,
+  },
+  {
+    id: 'response',
+    label: 'Resposta',
+    language: 'json',
+    file: '200 OK',
+    code: `{
+  "charge": {
+    "status": "ACTIVE",
+    "correlationID": "pedido-4321",
+    "value": 1990,
+    "brCode": "00020101021226980014br.gov.bcb.pix...",
+    "paymentLinkUrl": "https://woovi.com/pay/9134e286...",
+    "qrCodeImage": "https://api.woovi.com/openpix/charge/brcode/image/9134e286....png",
+    "expiresIn": 2592000
+  }
+}`,
+  },
+  {
+    id: 'webhook',
+    label: 'Webhook',
+    language: 'json',
+    file: 'POST /seu-endpoint',
+    code: `{
+  "event": "OPENPIX:CHARGE_COMPLETED",
+  "charge": {
+    "correlationID": "pedido-4321",
+    "status": "COMPLETED",
+    "value": 1990,
+    "paidAt": "2025-09-24T15:07:50.891Z"
+  },
+  "pix": {
+    "value": 1990,
+    "endToEndId": "E1234567890",
+    "time": "2025-09-24T15:07:50.891Z"
+  }
+}`,
+  },
+];
+
+const CodeCard = () => {
+  const [activeId, setActiveId] = useState(snippets[0].id);
+  const [copied, setCopied] = useState(false);
+
+  const active = snippets.find((snippet) => snippet.id === activeId) as Snippet;
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(active.code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className={styles['code-card']}>
+      <div className={styles['code-card--tabs']} role='tablist'>
+        {snippets.map((snippet) => (
+          <button
+            key={snippet.id}
+            type='button'
+            role='tab'
+            aria-selected={snippet.id === activeId}
+            aria-controls='hero-code-panel'
+            className={clsx(
+              styles['code-card--tab'],
+              snippet.id === activeId && styles['code-card--tab-active'],
+            )}
+            onClick={() => setActiveId(snippet.id)}
+          >
+            {snippet.label}
+          </button>
+        ))}
+      </div>
+
+      <div className={styles['code-card--bar']}>
+        <span className={styles['code-card--file']}>{active.file}</span>
+        <button
+          type='button'
+          className={styles['code-card--copy']}
+          onClick={onCopy}
+        >
+          {copied ? 'Copiado!' : 'Copiar'}
+        </button>
+      </div>
+
+      <pre
+        id='hero-code-panel'
+        role='tabpanel'
+        tabIndex={0}
+        aria-label={active.label}
+        className={styles['code-card--pre']}
+      >
+        <code>{highlight(active.code, active.language)}</code>
+      </pre>
+    </div>
+  );
+};
+
+export { CodeCard };

--- a/src/components/Hero/Hero.module.css
+++ b/src/components/Hero/Hero.module.css
@@ -1,0 +1,379 @@
+.hero {
+  --hero-ink: #f3fffb;
+  --hero-muted: rgba(228, 245, 239, 0.72);
+  --hero-brand: #03d69d;
+
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  color: var(--hero-ink);
+  background:
+    radial-gradient(
+      120% 120% at 8% -10%,
+      rgba(3, 214, 157, 0.22),
+      transparent 55%
+    ),
+    linear-gradient(160deg, #071b16 0%, #04100e 45%, #030807 100%);
+}
+
+/* WebGL layer (and the classes the threeui component renders with). */
+.shader {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+}
+
+.shader :global(.threeui-background) {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: transparent;
+}
+
+.shader :global(.threeui-background > canvas) {
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* Keeps the headline readable on top of the animation. */
+.scrim {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background:
+    linear-gradient(
+      100deg,
+      rgba(3, 8, 7, 0.86) 0%,
+      rgba(3, 8, 7, 0.55) 45%,
+      rgba(3, 8, 7, 0.12) 100%
+    ),
+    linear-gradient(to bottom, transparent 62%, rgba(3, 8, 7, 0.6) 100%);
+}
+
+.inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  align-items: center;
+  column-gap: clamp(2rem, 4vw, 3.5rem);
+  row-gap: clamp(1.5rem, 3vw, 2.5rem);
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: clamp(3rem, 7vw, 5rem) clamp(1.25rem, 5vw, 2.5rem);
+}
+
+.copy {
+  min-width: 0;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.85rem;
+  border: 1px solid rgba(3, 214, 157, 0.35);
+  border-radius: 999px;
+  background: rgba(3, 214, 157, 0.08);
+  color: #9df3d9;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.eyebrow--dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--hero-brand);
+  box-shadow: 0 0 0 4px rgba(3, 214, 157, 0.18);
+}
+
+.title {
+  margin: 1.4rem 0 0;
+  font-size: clamp(2.3rem, 5.4vw, 3.7rem);
+  font-weight: 800;
+  line-height: 1.04;
+  letter-spacing: -0.025em;
+  color: var(--hero-ink);
+}
+
+.title--accent {
+  background: linear-gradient(96deg, #03d69d 0%, #5ee7c1 48%, #7fe4ff 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+.subtitle {
+  max-width: 34rem;
+  margin: 1.1rem 0 0;
+  font-size: clamp(1rem, 1.6vw, 1.15rem);
+  line-height: 1.6;
+  color: var(--hero-muted);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    background-color 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.button--primary {
+  background: var(--hero-brand);
+  color: #042219;
+  box-shadow: 0 14px 34px -14px rgba(3, 214, 157, 0.85);
+}
+
+.button--primary:hover {
+  color: #042219;
+  background: #1ce4ae;
+  box-shadow: 0 18px 40px -14px rgba(3, 214, 157, 0.95);
+}
+
+.button--ghost {
+  border: 1px solid rgba(243, 255, 251, 0.28);
+  background: rgba(243, 255, 251, 0.06);
+  color: var(--hero-ink);
+  backdrop-filter: blur(8px);
+}
+
+.button--ghost:hover {
+  color: var(--hero-ink);
+  border-color: rgba(3, 214, 157, 0.65);
+  background: rgba(3, 214, 157, 0.12);
+}
+
+.stats {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  margin: 0;
+  padding-top: 1.75rem;
+  border-top: 1px solid rgba(243, 255, 251, 0.12);
+}
+
+.stats--item {
+  min-width: 0;
+}
+
+.stats--item dt {
+  font-size: 1.35rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--hero-ink);
+}
+
+.stats--item dd {
+  max-width: 15rem;
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: var(--hero-muted);
+}
+
+.secondary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 1.5rem 0 0;
+  font-size: 0.9rem;
+  color: var(--hero-muted);
+}
+
+.secondary a {
+  color: #9df3d9;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(157, 243, 217, 0.35);
+}
+
+.secondary a:hover {
+  color: #ffffff;
+  border-bottom-color: #ffffff;
+}
+
+/* Code showcase */
+.showcase {
+  min-width: 0;
+}
+
+.code-card {
+  overflow: hidden;
+  border: 1px solid rgba(243, 255, 251, 0.14);
+  border-radius: 18px;
+  background: rgba(4, 12, 10, 0.72);
+  box-shadow: 0 40px 80px -40px rgba(0, 0, 0, 0.9);
+  backdrop-filter: blur(16px);
+}
+
+.code-card--tabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.5rem 0.5rem 0;
+  border-bottom: 1px solid rgba(243, 255, 251, 0.1);
+}
+
+.code-card--tab {
+  padding: 0.5rem 0.85rem;
+  border: 0;
+  border-radius: 10px 10px 0 0;
+  background: transparent;
+  color: rgba(228, 245, 239, 0.6);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.code-card--tab:hover {
+  color: var(--hero-ink);
+  background: rgba(243, 255, 251, 0.06);
+}
+
+.code-card--tab-active {
+  color: var(--hero-ink);
+  background: rgba(3, 214, 157, 0.14);
+  box-shadow: inset 0 -2px 0 0 var(--hero-brand);
+}
+
+.code-card--bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid rgba(243, 255, 251, 0.08);
+}
+
+.code-card--file {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  color: rgba(228, 245, 239, 0.55);
+}
+
+.code-card--copy {
+  padding: 0.3rem 0.7rem;
+  border: 1px solid rgba(243, 255, 251, 0.18);
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(228, 245, 239, 0.8);
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.code-card--copy:hover {
+  color: var(--hero-brand);
+  border-color: rgba(3, 214, 157, 0.6);
+}
+
+.code-card--pre {
+  max-height: 20rem;
+  margin: 0;
+  padding: 1.1rem 1.15rem 1.35rem;
+  overflow: auto;
+  background: transparent;
+  color: #d8ece5;
+  font-size: 0.78rem;
+  line-height: 1.65;
+  tab-size: 2;
+}
+
+.token-keyword {
+  color: #7fe4ff;
+  font-weight: 600;
+}
+
+.token-flag {
+  color: #f5c973;
+}
+
+.token-string {
+  color: #9df3d9;
+}
+
+.token-key {
+  color: #7fe4ff;
+}
+
+.token-url {
+  color: #d8b4fe;
+}
+
+.token-number {
+  color: #ffb4a2;
+}
+
+.token-literal {
+  color: #f5c973;
+}
+
+.token-comment {
+  color: rgba(216, 236, 229, 0.45);
+  font-style: italic;
+}
+
+@media screen and (max-width: 996px) {
+  .inner {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .scrim {
+    background: linear-gradient(
+      180deg,
+      rgba(3, 8, 7, 0.86) 0%,
+      rgba(3, 8, 7, 0.72) 55%,
+      rgba(3, 8, 7, 0.92) 100%
+    );
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .stats {
+    gap: 1.25rem;
+  }
+
+  .stats--item dd {
+    max-width: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button:hover {
+    transform: none;
+  }
+}

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import clsx from 'clsx';
+
+import styles from './Hero.module.css';
+import { HeroBackground } from './HeroBackground';
+import { CodeCard } from './CodeCard';
+
+type Props = {
+  integrationsCount: number;
+};
+
+const Hero = ({ integrationsCount }: Props) => {
+  return (
+    <header className={styles.hero}>
+      <HeroBackground />
+      <div className={styles.scrim} aria-hidden='true' />
+
+      <div className={styles.inner}>
+        <div className={styles.copy}>
+          <span className={styles.eyebrow}>
+            <span className={styles['eyebrow--dot']} />
+            API Pix, webhooks em tempo real e SDKs
+          </span>
+
+          <h1 className={styles.title}>
+            Pix na sua aplicação
+            <br />
+            <span className={styles['title--accent']}>em minutos</span>
+          </h1>
+
+          <p className={styles.subtitle}>
+            Documentação, APIs e SDKs da Woovi para criar cobranças, receber a
+            confirmação do pagamento no mesmo segundo e integrar Pix onde você
+            já vende.
+          </p>
+
+          <div className={styles.actions}>
+            <Link
+              className={clsx(styles.button, styles['button--primary'])}
+              to='/docs/intro/getting-started'
+            >
+              Começar agora
+            </Link>
+            <Link
+              className={clsx(styles.button, styles['button--ghost'])}
+              to='/api'
+            >
+              Explorar a API
+            </Link>
+          </div>
+
+          <p className={styles.secondary}>
+            <Link to='/docs/test-environment'>Ambiente de teste</Link>
+            <span aria-hidden='true'>·</span>
+            <Link to='/docs/apis/api-getting-started'>Chaves de API</Link>
+            <span aria-hidden='true'>·</span>
+            <Link to='/docs/webhook/platform/webhook-platform-api'>
+              Webhooks
+            </Link>
+          </p>
+        </div>
+
+        <div className={styles.showcase}>
+          <CodeCard />
+        </div>
+
+        <dl className={styles.stats}>
+          <div className={styles['stats--item']}>
+            <dt>{integrationsCount}+</dt>
+            <dd>integrações e plugins prontos</dd>
+          </div>
+          <div className={styles['stats--item']}>
+            <dt>Webhooks</dt>
+            <dd>eventos de pagamento em tempo real</dd>
+          </div>
+          <div className={styles['stats--item']}>
+            <dt>Sandbox</dt>
+            <dd>ambiente de teste gratuito</dd>
+          </div>
+        </dl>
+      </div>
+    </header>
+  );
+};
+
+export { Hero };

--- a/src/components/Hero/HeroBackground.tsx
+++ b/src/components/Hero/HeroBackground.tsx
@@ -1,0 +1,62 @@
+import React, { Suspense, lazy, useEffect, useState } from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+
+import styles from './Hero.module.css';
+
+// The shader lives in its own async chunk so it never touches the initial payload.
+// To swap the look, point this import at another threeui background component and
+// update the module declaration in `src/global.d.ts`. Other WebGL-only options
+// (no extra `three` chunk): LiquidFormBackground, DotMatrixBackground,
+// CondensationBackground, CrtBackground.
+const RibbonField = lazy(() =>
+  import('@designcodeio/threeui/components/RibbonFieldBackground').then(
+    (mod) => ({ default: mod.RibbonFieldBackground }),
+  ),
+);
+
+const hasWebGL = () => {
+  try {
+    const canvas = document.createElement('canvas');
+
+    return Boolean(
+      canvas.getContext('webgl') || canvas.getContext('experimental-webgl'),
+    );
+  } catch {
+    return false;
+  }
+};
+
+const ShaderLayer = () => {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const webgl = hasWebGL();
+    const update = () => setEnabled(webgl && !media.matches);
+
+    update();
+    media.addEventListener('change', update);
+
+    return () => media.removeEventListener('change', update);
+  }, []);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <RibbonField hue={-24} saturation={1.1} brightness={1.05} speed={0.85} />
+    </Suspense>
+  );
+};
+
+// Animated WebGL ribbons behind the hero. Falls back to the CSS gradient
+// underneath on SSR, without WebGL, or with `prefers-reduced-motion`.
+const HeroBackground = () => (
+  <div className={styles.shader} aria-hidden='true'>
+    <BrowserOnly>{() => <ShaderLayer />}</BrowserOnly>
+  </div>
+);
+
+export { HeroBackground };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,3 +3,22 @@ declare module '*.module.css' {
 
   export default classes;
 }
+
+// The package ships types behind an "exports" map, which this project's
+// `moduleResolution: node` cannot read. Declare the subpath we use.
+declare module '@designcodeio/threeui/components/RibbonFieldBackground' {
+  export type RibbonFieldBackgroundProps = {
+    speed?: number;
+    pointerAmount?: number;
+    smoothing?: number;
+    brightness?: number;
+    opacity?: number;
+    hue?: number;
+    saturation?: number;
+    className?: string;
+  };
+
+  export function RibbonFieldBackground(
+    props: RibbonFieldBackgroundProps,
+  ): JSX.Element;
+}

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,15 +1,11 @@
 .home-section {
-  padding: 2vh 5vw;
-}
-
-@media screen and (min-width: 720px) {
-  .home-section {
-    padding: 5vh 20vw;
-  }
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: clamp(2.5rem, 6vw, 4rem) clamp(1.25rem, 5vw, 2.5rem);
 }
 
 .home-section > :not(:first-child) {
-  margin: 5vh 0;
+  margin-top: clamp(3rem, 7vw, 4.5rem);
 }
 
 /* reset margin */
@@ -24,9 +20,24 @@ html[data-theme='dark'] .dark-mode--override h3 {
   color: white;
 }
 
+.section-title {
+  margin-bottom: 0.35rem;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.section-lead {
+  max-width: 42rem;
+  margin-bottom: 1.5rem !important;
+  color: var(--ifm-color-emphasis-700) !important;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
 .section-box {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 20px;
 }
 
@@ -36,11 +47,37 @@ html[data-theme='dark'] .dark-mode--override h3 {
   gap: 18px;
 }
 
-/* just to reset hover state */
+.products--item {
+  padding: 1.1rem 1.25rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 14px;
+  background: var(--ifm-background-surface-color);
+  text-decoration: none;
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
 .products--item:hover {
-  color: black;
+  transform: translateY(-2px);
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 16px 32px -22px rgba(0, 0, 0, 0.5);
+  text-decoration: none;
 }
 
 .products--item > h3 {
   font-size: 16px;
+}
+
+.products--item > p {
+  margin-top: 0.35rem !important;
+  color: var(--ifm-color-emphasis-700) !important;
+  font-size: 0.9rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .products--item:hover {
+    transform: none;
+  }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,6 +20,7 @@ import { SiZapier } from 'react-icons/si';
 import Layout from '@theme/Layout';
 
 import styles from './index.module.css';
+import { Hero } from '../components/Hero/Hero';
 import { CardLink } from '../components/Card/CardLink';
 import BotConversaIcon from '../icons/BotConversaIcon';
 import SocPanelIcon from '../icons/SocPanelIcon';
@@ -130,7 +131,7 @@ const cards = [
   {
     title: 'API REST',
     content: 'API REST. Crie cobranças do seu back-end.',
-    icon: <FaReact color={'#353535'} size={30} />,
+    icon: <FaReact color={'var(--ifm-font-color-base)'} size={30} />,
     docsTo:
       '/docs/apis/api-getting-started#criando-uma-nova-chave-de-apiplugin',
     to: 'https://app.woovi.com/home/applications/api/add',
@@ -147,7 +148,7 @@ const cards = [
     title: 'Webhook',
     content:
       'Seja avisado em tempo real sempre que um pagamento via Pix for realizado.',
-    icon: <TbWebhook color={'#353535'} size={30} />,
+    icon: <TbWebhook color={'var(--ifm-font-color-base)'} size={30} />,
     docsTo: '/docs/webhook/platform/webhook-platform-api',
     to: 'https://app.woovi.com/home/applications/webhook/create',
   },
@@ -270,12 +271,21 @@ const cards = [
 
 const Home = () => {
   return (
-    <Layout>
+    <Layout
+      title='Woovi Developers'
+      description='Documentação, APIs e SDKs da Woovi para integrar Pix: cobranças, webhooks em tempo real, plugins de e-commerce e ambiente de teste.'
+    >
+      <Hero integrationsCount={cards.length} />
+
       <main
         className={clsx(styles['home-section'], styles['dark-mode--override'])}
       >
         <section>
-          <h2>Comece por aqui</h2>
+          <h2 className={clsx(styles['section-title'])}>Comece por aqui</h2>
+          <p className={clsx(styles['section-lead'])}>
+            O caminho mais curto entre a sua primeira chave de API e a primeira
+            cobrança Pix paga.
+          </p>
           <section className={clsx(styles['section-box'])}>
             {links.map((link, i) => (
               <CardLink
@@ -289,7 +299,11 @@ const Home = () => {
         </section>
 
         <section>
-          <h2>Nossas integrações</h2>
+          <h2 className={clsx(styles['section-title'])}>Nossas integrações</h2>
+          <p className={clsx(styles['section-lead'])}>
+            Plugins, SDKs e automações prontas para você não escrever código que
+            já existe.
+          </p>
           <section className={clsx(styles['section-box'])}>
             {cards.map(({ icon, docsTo, title, content }, key) => (
               <CardLink
@@ -304,7 +318,7 @@ const Home = () => {
         </section>
 
         <section>
-          <h2>Nossos produtos</h2>
+          <h2 className={clsx(styles['section-title'])}>Nossos produtos</h2>
           <section className={clsx(styles['products'])}>
             {products.map((product, i) => (
               <Link
@@ -320,7 +334,9 @@ const Home = () => {
         </section>
 
         <section>
-          <h2>Bibliotecas da Comunidade</h2>
+          <h2 className={clsx(styles['section-title'])}>
+            Bibliotecas da Comunidade
+          </h2>
           <section className={clsx(styles['products'])}>
             {communityLibraries.map((lib, i) => (
               <Link


### PR DESCRIPTION
## What

Rebuilds the homepage around a hero section instead of dropping visitors straight into card lists.

- **Hero** (`src/components/Hero/`) with a lazy-loaded [threeui](https://github.com/MengTo/threeui) `RibbonFieldBackground` shader, hue-tuned toward the Woovi green (`#03d69d`).
- **Tabbed code card** — create charge / response / webhook — with a copy button. Payloads are the real ones from `src/swaggers/woovi.json` and `docs/webhook/examples/charge-payload.mdx`.
- Page `title`/`description` for SEO, section lead-ins, bordered cards with hover, and even card grids (`repeat(auto-fill, minmax(280px, 1fr))`) so rows line up instead of stretching.
- Two `#353535` icon colors move to `var(--ifm-font-color-base)` so they stay visible in dark mode.

All existing links and sections are kept.

## Cost and fallbacks

- The shader ships as a single **~8KB async chunk**, loaded only in the browser after mount — `grep -rl WebGLRenderer build/assets/js` is empty, so `three` never enters the bundle (it is only present to satisfy threeui's peer dependency).
- No WebGL, or `prefers-reduced-motion: reduce` → the shader is never mounted and the CSS gradient underneath shows instead.
- threeui's 57KB `style.css` is not imported; the four rules the component needs are scoped in `Hero.module.css`.

## Verified

- `pnpm build` succeeds for both locales.
- 1440 / 1024 / 390px, light + dark theme, and the reduced-motion fallback.
- No new console errors (the remaining ones are the pre-existing `defaultProps` warnings from the icon components).

## Notes

- Hero copy is hardcoded pt-BR, matching the existing page, which does not use `<Translate>`. `/en` therefore shows Portuguese in the hero too.
- threeui hides its types behind an `exports` map that this repo's `moduleResolution: node` cannot read, so the subpath is declared in `src/global.d.ts` — update it when swapping shaders. `HeroBackground.tsx` lists the other WebGL-only options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdMFFBq34TTYR6QFh5PAsP