### PR TITLE
docs(flows): rewrite validate-bank-data around the validated 1-cent flow

### DIFF
--- a/docs/flows/validate-bank-data.md
+++ b/docs/flows/validate-bank-data.md
@@ -74,7 +74,23 @@ curl --location 'https://api.woovi.com/api/v1/payment' \
 
 ### Opção 2: aprovação em dois passos
 
-Sem o `autoApprove`, o pagamento é criado com status `CREATED` e você precisa aprová-lo em uma segunda chamada, seguindo o endpoint [Approve a Payment Request](<https://developers.woovi.com/api#tag/payment-(request-access)/paths/~1api~1v1~1payment~1approve/post>). Essa chamada exige o escopo `PAYMENT_APPROVE_POST` no AppID.
+Sem o `autoApprove`, o mesmo `POST /api/v1/payment` cria o pagamento com status `CREATED`, sem enviar o Pix:
+
+```json
+{
+  "payment": {
+    "value": 1,
+    "status": "CREATED",
+    "destinationAlias": "07*******61",
+    "destinationAliasType": "CPF",
+    "comment": "request user information",
+    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001",
+    "sourceAccountId": "6823414a524ed520d3518dd6"
+  }
+}
+```
+
+Aprove em uma segunda chamada, seguindo o endpoint [Approve a Payment Request](<https://developers.woovi.com/api#tag/payment-(request-access)/paths/~1api~1v1~1payment~1approve/post>). Essa chamada exige o escopo `PAYMENT_APPROVE_POST` no AppID e envia apenas o `correlationID`.
 
 ```bash
 curl --location 'https://api.woovi.com/api/v1/payment/approve' \
@@ -83,6 +99,19 @@ curl --location 'https://api.woovi.com/api/v1/payment/approve' \
   --data '{
     "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001"
   }'
+```
+
+```json
+{
+  "payment": {
+    "status": "APPROVED",
+    "value": 1,
+    "destinationAlias": "07*******61",
+    "comment": "request user information",
+    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001",
+    "sourceAccountId": "6823414a524ed520d3518dd6"
+  }
+}
 ```
 
 > A criação **não** valida a chave: um pagamento para uma chave inexistente é criado normalmente e só falha depois de aprovado. E nenhuma das duas chamadas retorna os dados do titular — o Pix é liquidado de forma assíncrona, então esse dado só existe depois da confirmação. Para obtê-lo, consulte o pagamento (próximo passo).

--- a/docs/flows/validate-bank-data.md
+++ b/docs/flows/validate-bank-data.md
@@ -7,11 +7,15 @@ tags:
 
 Este documento irá ajudá-lo a validar os dados bancários de um beneficiário a partir de uma **chave Pix** (CPF, CNPJ, e-mail, telefone ou chave aleatória).
 
-A validação é feita iniciando um pagamento de 1 centavo para a chave informada. O banco do recebedor resolve a chave via DICT e confirma a quem ela pertence — esses dados ficam disponíveis consultando a transação depois da confirmação do pagamento.
+A validação é feita enviando um pagamento de 1 centavo para a chave informada. O banco do recebedor resolve a chave e confirma a quem ela pertence — esses dados voltam na consulta do próprio pagamento, depois que ele é confirmado.
 
-> **Pré-requisitos:** ter uma [API MASTER](../apis/api-master.md) e o **PIX OUT habilitado** na conta. Caso não tenha o Pix Out, solicite seguindo o artigo [Como ativar o Pix Out (pagamento externo)](https://ajuda.woovi.com/hc/duvidas-frequentes/articles/como-ativar-o-pix-out-pagamento-externo).
+> **Pré-requisitos**
+>
+> - Um **AppID** com os escopos `PAYMENT_POST` (criar pagamento) e `PAYMENT_GET` (consultar pagamento). Você cria o AppID no app, em **Integrações → API**.
+> - **Pix Out habilitado** na sua empresa **e** na conta que vai pagar. A liberação da conta é feita por você mesmo, seguindo o artigo [Como ativar o Pix Out (pagamento externo)](https://ajuda.woovi.com/hc/duvidas-frequentes/articles/como-ativar-o-pix-out-pagamento-externo).
+> - Saldo na conta de origem — o Pix de 1 centavo é real e a tarifa de pagamento é cobrada normalmente.
 
-## 1. Crie o pagamento
+## 1. Crie e aprove o pagamento
 
 Crie o pagamento informando a chave Pix do beneficiário, seguindo os parâmetros do endpoint [Create Payment request](<https://developers.woovi.com/api#tag/payment-(request-access)/paths/~1api~1v1~1payment/post>).
 
@@ -19,8 +23,11 @@ Crie o pagamento informando a chave Pix do beneficiário, seguindo os parâmetro
 
 | Campo | Descrição |
 | --- | --- |
+| value | Valor em centavos — use `1` para validar |
+| correlationID | Identificador único seu, usado depois para consultar o pagamento |
 | destinationAlias | Valor da chave Pix do beneficiário |
 | destinationAliasType | Tipo da chave — ver tabela abaixo |
+| autoApprove | `true` cria e aprova o pagamento na mesma chamada |
 
 #### Tipos de chave (destinationAliasType)
 
@@ -32,28 +39,9 @@ Crie o pagamento informando a chave Pix do beneficiário, seguindo os parâmetro
 | PHONE | Chave de telefone |
 | RANDOM | Chave aleatória (EVP) |
 
-```bash
-curl --location 'https://api.woovi.com/api/v1/payment' \
-  --header 'Authorization: {APP_ID}' \
-  --header 'Content-Type: application/json' \
-  --data '{
-    "value": 1,
-    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001",
-    "comment": "request user information",
-    "destinationAlias": "07*******61",
-    "destinationAliasType": "CPF"
-  }'
-```
+### Opção 1: chamada única (`autoApprove`)
 
-## 2. Aprove o pagamento
-
-Há **duas formas** de aprovar o pagamento:
-
-### Opção 1: Aprovação automática (`autoApprove`) — chamada única
-
-Enviando `autoApprove: true` no corpo da requisição do `/api/v1/payment` (a mesma da etapa anterior), o pagamento é criado **e aprovado na mesma chamada**, dispensando o `/api/v1/payment/approve`.
-
-> **Atenção:** o uso do `autoApprove` requer permissão especial na sua conta. Entre em contato com o suporte para ativar. Veja mais em [Como criar e aprovar um pagamento em uma única chamada?](../payment/payment-how-to-auto-approve.md).
+Enviando `autoApprove: true`, o pagamento é criado **e aprovado na mesma chamada**, dispensando o `/api/v1/payment/approve`.
 
 ```bash
 curl --location 'https://api.woovi.com/api/v1/payment' \
@@ -69,9 +57,24 @@ curl --location 'https://api.woovi.com/api/v1/payment' \
   }'
 ```
 
-### Opção 2: Aprovação em dois passos (`/payment/approve`)
+```json
+{
+  "payment": {
+    "status": "APPROVED",
+    "value": 1,
+    "destinationAlias": "07*******61",
+    "comment": "request user information",
+    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001",
+    "sourceAccountId": "6823414a524ed520d3518dd6"
+  }
+}
+```
 
-Sem o `autoApprove`, o pagamento é criado com status `CREATED` e você precisa aprová-lo em uma segunda chamada, seguindo o endpoint [Approve a Payment Request](<https://developers.woovi.com/api#tag/payment-(request-access)/paths/~1api~1v1~1payment~1approve/post>).
+> **Atenção:** o `autoApprove` requer permissão específica na sua conta. Se a resposta vier `403` com `Your company does not have access to autoApprove payments via API`, use a Opção 2. Veja mais em [Como criar e aprovar um pagamento em uma única chamada?](../payment/payment-how-to-auto-approve.md).
+
+### Opção 2: aprovação em dois passos
+
+Sem o `autoApprove`, o pagamento é criado com status `CREATED` e você precisa aprová-lo em uma segunda chamada, seguindo o endpoint [Approve a Payment Request](<https://developers.woovi.com/api#tag/payment-(request-access)/paths/~1api~1v1~1payment~1approve/post>). Essa chamada exige o escopo `PAYMENT_APPROVE_POST` no AppID.
 
 ```bash
 curl --location 'https://api.woovi.com/api/v1/payment/approve' \
@@ -82,14 +85,14 @@ curl --location 'https://api.woovi.com/api/v1/payment/approve' \
   }'
 ```
 
-> **Atenção:** nem o `POST /api/v1/payment` nem o `POST /api/v1/payment/approve` retornam os dados do titular da chave — a resposta de ambos traz só o `payment` (status, valor, correlationID etc). O Pix é liquidado de forma assíncrona, então o dado do titular só existe depois da confirmação. Para obtê-lo, consulte a transação — veja o próximo passo.
+> A criação **não** valida a chave: um pagamento para uma chave inexistente é criado normalmente e só falha depois de aprovado. E nenhuma das duas chamadas retorna os dados do titular — o Pix é liquidado de forma assíncrona, então esse dado só existe depois da confirmação. Para obtê-lo, consulte o pagamento (próximo passo).
 
-## 3. Consulte a transação para obter os dados do titular
+## 2. Consulte o pagamento para obter os dados do titular
 
-Depois que o pagamento é confirmado (veja o webhook no passo 4, que traz o `endToEndId`), consulte [`GET /api/v1/transaction/{id}`](<https://developers.woovi.com/api#tag/transactions/paths/~1api~1v1~1transaction~1{id}/get>) usando o `endToEndId` (ou o `transactionID`) recebido. Os dados do titular da chave vêm no campo **`creditParty`**:
+Consulte [`GET /api/v1/payment/{id}`](<https://developers.woovi.com/api#tag/payment-(request-access)/paths/~1api~1v1~1payment~1%7Bid%7D/get>) usando o `correlationID` que você enviou. Depois que o pagamento fica `CONFIRMED`, a resposta traz os dados do titular da chave no bloco **`destination`** (e os mesmos dados, completos, em `transaction.creditParty`).
 
 ```bash
-curl --location 'https://api.woovi.com/api/v1/transaction/E00416968202608010010NRGg4kHJ3D0' \
+curl --location 'https://api.woovi.com/api/v1/payment/c0938e0c-a613-48a9-982a-672c062d0001' \
   --header 'Authorization: {APP_ID}'
 ```
 
@@ -97,68 +100,87 @@ Exemplo real de resposta (dados sensíveis mascarados abaixo apenas para fins de
 
 ```json
 {
+  "payment": {
+    "status": "CONFIRMED",
+    "value": 1,
+    "destinationAlias": "07*******61",
+    "comment": "request user information",
+    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001",
+    "sourceAccountId": "6823414a524ed520d3518dd6"
+  },
   "transaction": {
     "value": 1,
-    "endToEndId": "E00416968202608010010NRGg4kHJ3D0",
-    "type": "PAYMENT",
-    "status": "CONFIRMED",
+    "time": "2026-08-24T20:11:01.783Z",
+    "endToEndId": "E54811417202608242011RymkUzu7ANw",
     "creditParty": {
-      "holder": {
-        "name": "VAKI****** N******* V******* LTDA",
-        "nameFriendly": "VAKI****** N******* V******* LTDA",
-        "taxID": {
-          "taxID": "228*******26",
-          "type": "BR:CNPJ"
-        }
-      },
       "pixKey": {
-        "pixKey": "624****0@*******.com.br",
-        "type": "EMAIL"
+        "pixKey": "07*******61",
+        "type": "CPF"
       },
       "account": {
-        "branch": "0001",
-        "account": "0000000000000****501",
+        "branch": "1",
+        "account": "709*****1",
         "accountType": "TRAN"
       },
       "psp": {
-        "id": "54811417",
-        "name": "WOOVI IP LTDA."
+        "id": "37880206",
+        "name": "CORA SCFI"
+      },
+      "holder": {
+        "name": "LUC** ****** ****",
+        "nameFriendly": "LUC** ****** ****",
+        "taxID": {
+          "taxID": "07*******61",
+          "type": "BR:CPF"
+        }
       }
     }
+  },
+  "destination": {
+    "name": "LUC** ****** ****",
+    "taxID": "07*******61",
+    "pixKey": "07*******61",
+    "bank": "CORA SCFI",
+    "branch": "1",
+    "account": "709*****1"
   }
 }
 ```
 
 > O mascaramento acima (`****`) foi aplicado só nesta documentação — a resposta real da API **não** vem mascarada, traz o `name`/`taxID`/`account` completos, exatamente como resolvidos pelo banco.
 
-- `creditParty.holder.name` / `taxID` — nome e documento do titular da chave, resolvidos pelo banco do recebedor via DICT no momento da liquidação. Diferente do fluxo por [agência e conta](./validate-bank-data-manual.md) (onde você mesmo informa o nome e ele nunca é validado), aqui o nome vem **do banco**, não do que você enviou.
-- `creditParty.pixKey` — a chave Pix usada (`destinationAlias`) e seu tipo.
-- `creditParty.account` / `psp` — agência, conta e instituição financeira vinculadas à chave.
+- `destination.name` / `destination.taxID` — nome e documento do titular da chave, resolvidos pelo banco do recebedor no momento da liquidação. Diferente de uma validação em que você mesmo informa o nome, aqui o nome vem **do banco**, não do que você enviou.
+- `destination.pixKey` — a chave Pix usada (`destinationAlias`).
+- `destination.bank` / `branch` / `account` — instituição financeira, agência e conta vinculadas à chave.
+- `transaction.endToEndId` — identificador do Pix no Banco Central, útil para conciliação.
 
-> Se o pagamento for **rejeitado** (`status: FAILED`/`REJECTED`), a transação não terá `creditParty` preenchido — nesse caso, confie apenas no `providerRejectedReason` para saber o motivo. Veja a lista de códigos em [Error codes - Payment](./error-codes-payment.md).
+> O bloco `destination` só aparece com o pagamento `CONFIRMED`. Enquanto o status for `CREATED` ou `APPROVED`, a resposta traz apenas o `payment` — a confirmação costuma levar poucos segundos.
 
-## 4. Webhooks
+## 3. Quando a chave não existe ou o pagamento é rejeitado
 
-Após a criação e confirmação do pagamento, você receberá webhooks com o status da transação — é deles que você extrai o `endToEndId` para consultar a transação no passo anterior.
-
-### Webhook de falha (`MOVEMENT_FAILED`)
+Se a chave não estiver cadastrada em nenhum banco (ou o PSP do recebedor rejeitar o Pix), o pagamento vai para `FAILED`, **sem** `transaction` e **sem** `destination`, e o motivo vem no bloco `error`:
 
 ```json
 {
-  "event": "OPENPIX:MOVEMENT_FAILED",
   "payment": {
-    "value": 1,
     "status": "FAILED",
-    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001"
-  },
-  "transaction": {
     "value": 1,
-    "endToEndId": "E54811417202507081527dYr4Cp2gfAp",
-    "time": "2025-07-08T15:27:19.687Z",
-    "providerRejectedReason": "AC03 - Pagamento rejeitado pelo PSP do recebedor"
+    "destinationAlias": "chave-inexistente@exemplo.com",
+    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0002",
+    "sourceAccountId": "6823414a524ed520d3518dd6"
+  },
+  "error": {
+    "code": "PIX_KEY_INFO_NOT_FOUND",
+    "description": "A chave pix não esta cadastrada em um banco"
   }
 }
 ```
+
+Nesse caso o dinheiro não sai da conta. Quando a rejeição vem do banco do recebedor, o código também aparece em `transaction.providerRejectedReason` — veja a lista em [Error codes - Payment](./error-codes-payment.md).
+
+## 4. Webhooks (opcional)
+
+Para não ficar consultando o pagamento em intervalos, configure um webhook e reaja ao evento de confirmação ou de falha. Nenhum dos dois traz os dados do titular — use o `correlationID` deles para consultar o pagamento (passo 2).
 
 ### Webhook de confirmação (`MOVEMENT_CONFIRMED`)
 
@@ -173,13 +195,30 @@ Após a criação e confirmação do pagamento, você receberá webhooks com o s
   },
   "transaction": {
     "value": 1,
-    "time": "2025-07-08T15:27:19.687Z",
-    "endToEndId": "E54811417202507081527dYr4Cp2gfAp"
+    "time": "2026-08-24T20:11:01.783Z",
+    "endToEndId": "E54811417202608242011RymkUzu7ANw"
   }
 }
 ```
 
-> Nenhum dos dois webhooks traz os dados do titular (`creditParty`) — use o `endToEndId` deles para consultar `GET /api/v1/transaction/{id}` (passo 3).
+### Webhook de falha (`MOVEMENT_FAILED`)
+
+```json
+{
+  "event": "OPENPIX:MOVEMENT_FAILED",
+  "payment": {
+    "value": 1,
+    "status": "FAILED",
+    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0002"
+  },
+  "transaction": {
+    "value": 1,
+    "endToEndId": "E54811417202608242011RymkUzu7ANw",
+    "time": "2026-08-24T20:11:31.687Z",
+    "providerRejectedReason": "AC03 - Pagamento rejeitado pelo PSP do recebedor"
+  }
+}
+```
 
 Se não souber como configurar o webhook, acesse: [Criando um webhook para interceptar um Pix e chamar uma API](https://developers.woovi.com/docs/webhook/platform/webhook-platform-api).
 
@@ -187,12 +226,12 @@ Se não souber como configurar o webhook, acesse: [Criando um webhook para inter
 
 Copie o trecho abaixo numa IA de coding (Claude / Cursor / Gemini / ChatGPT) pra implementar a integração no seu app:
 
-> Implemente uma função `validateBankDataByPixKey({ destinationAlias, destinationAliasType })` que valida os dados bancários vinculados a uma chave Pix via Woovi, iniciando um pagamento de 1 centavo e devolvendo os dados do titular resolvidos pelo banco pra essa chave.
+> Implemente uma função `validateBankDataByPixKey({ destinationAlias, destinationAliasType })` que valida os dados bancários vinculados a uma chave Pix via Woovi, enviando um pagamento de 1 centavo e devolvendo os dados do titular resolvidos pelo banco pra essa chave.
 >
 > **Passo 1 — criar e aprovar o pagamento**:
 > `POST https://api.woovi.com/api/v1/payment`
-> Header: `Authorization: <APP_ID_MASTER>`, `Content-Type: application/json`
-> Pré-requisito: a conta precisa ter PIX OUT habilitado.
+> Header: `Authorization: <APP_ID>`, `Content-Type: application/json`
+> Pré-requisito: AppID com os escopos `PAYMENT_POST` e `PAYMENT_GET`, e Pix Out habilitado na empresa e na conta de origem.
 > ```json
 > {
 >   "value": 1,
@@ -202,10 +241,10 @@ Copie o trecho abaixo numa IA de coding (Claude / Cursor / Gemini / ChatGPT) pra
 >   "destinationAliasType": "CPF" | "CNPJ" | "EMAIL" | "PHONE" | "RANDOM"
 > }
 > ```
-> (`autoApprove: true` exige permissão especial na conta; sem ela, crie o pagamento e aprove depois com `POST /api/v1/payment/approve` enviando o `correlationID`.)
+> (`autoApprove: true` exige permissão específica na conta; sem ela, crie o pagamento e aprove depois com `POST /api/v1/payment/approve` enviando o `correlationID`, com o escopo `PAYMENT_APPROVE_POST`.)
 >
 > **A resposta do passo 1 NÃO traz os dados do titular** — traz só o status do pagamento. O Pix é liquidado de forma assíncrona.
 >
-> **Passo 2 — aguardar a confirmação**: trate os webhooks `OPENPIX:MOVEMENT_CONFIRMED` (aprovado) e `OPENPIX:MOVEMENT_FAILED` (rejeitado). Guarde o `endToEndId` de dentro de `transaction.endToEndId`.
+> **Passo 2 — buscar os dados do titular**: `GET https://api.woovi.com/api/v1/payment/{correlationID}`. Quando `payment.status` for `CONFIRMED`, os dados do titular vêm no bloco `destination` (`name`, `taxID`, `pixKey`, `bank`, `branch`, `account`) e, completos, em `transaction.creditParty`. Enquanto o status for `CREATED`/`APPROVED`, o `destination` ainda não existe — faça polling com backoff ou, melhor, trate os webhooks `OPENPIX:MOVEMENT_CONFIRMED` e `OPENPIX:MOVEMENT_FAILED` e consulte o pagamento ao receber o evento.
 >
-> **Passo 3 — buscar os dados do titular**: `GET https://api.woovi.com/api/v1/transaction/{endToEndId}`. Os dados confirmados do titular vêm em `transaction.creditParty` (`holder.name`, `holder.taxID`, `pixKey`, `account`, `psp`) — só existem se a transação foi confirmada. Se foi rejeitada, use `transaction.providerRejectedReason` para saber o motivo.
+> **Passo 3 — tratar falha**: se `payment.status` for `FAILED`, não há `transaction` nem `destination`; o motivo vem em `error.code` / `error.description` (ex.: `PIX_KEY_INFO_NOT_FOUND` = chave não cadastrada em nenhum banco) e, quando a rejeição é do banco do recebedor, em `transaction.providerRejectedReason`.

--- a/docs/flows/validate-bank-data.md
+++ b/docs/flows/validate-bank-data.md
@@ -9,11 +9,13 @@ Este documento irá ajudá-lo a validar os dados bancários de um beneficiário 
 
 A validação é feita enviando um pagamento de 1 centavo para a chave informada. O banco do recebedor resolve a chave e confirma a quem ela pertence — esses dados voltam na consulta do próprio pagamento, depois que ele é confirmado.
 
-> **Pré-requisitos**
->
-> - Um **AppID** com os escopos `PAYMENT_POST` (criar pagamento) e `PAYMENT_GET` (consultar pagamento). Você cria o AppID no app, em **Integrações → API**.
-> - **Pix Out habilitado** na sua empresa **e** na conta que vai pagar. A liberação da conta é feita por você mesmo, seguindo o artigo [Como ativar o Pix Out (pagamento externo)](https://ajuda.woovi.com/hc/duvidas-frequentes/articles/como-ativar-o-pix-out-pagamento-externo).
-> - Saldo na conta de origem — o Pix de 1 centavo é real e a tarifa de pagamento é cobrada normalmente.
+:::info Pré-requisitos
+
+- Um **AppID** com os escopos `PAYMENT_POST` (criar pagamento) e `PAYMENT_GET` (consultar pagamento). Você cria o AppID no app, em **Integrações → API**.
+- **Pix Out habilitado** na sua empresa **e** na conta que vai pagar. A liberação da conta é feita por você mesmo, seguindo o artigo [Como ativar o Pix Out (pagamento externo)](https://ajuda.woovi.com/hc/duvidas-frequentes/articles/como-ativar-o-pix-out-pagamento-externo).
+- Saldo na conta de origem — o Pix de 1 centavo é real e a tarifa de pagamento é cobrada normalmente.
+
+:::
 
 ## 1. Crie e aprove o pagamento
 
@@ -52,7 +54,7 @@ curl --location 'https://api.woovi.com/api/v1/payment' \
     "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001",
     "comment": "request user information",
     "autoApprove": true,
-    "destinationAlias": "07*******61",
+    "destinationAlias": "12345678909",
     "destinationAliasType": "CPF"
   }'
 ```
@@ -62,7 +64,7 @@ curl --location 'https://api.woovi.com/api/v1/payment' \
   "payment": {
     "status": "APPROVED",
     "value": 1,
-    "destinationAlias": "07*******61",
+    "destinationAlias": "12345678909",
     "comment": "request user information",
     "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001",
     "sourceAccountId": "6823414a524ed520d3518dd6"
@@ -70,7 +72,11 @@ curl --location 'https://api.woovi.com/api/v1/payment' \
 }
 ```
 
-> **Atenção:** o `autoApprove` requer permissão específica na sua conta. Se a resposta vier `403` com `Your company does not have access to autoApprove payments via API`, use a Opção 2. Veja mais em [Como criar e aprovar um pagamento em uma única chamada?](../payment/payment-how-to-auto-approve.md).
+:::caution Atenção
+
+O `autoApprove` requer permissão específica na sua conta. Se a resposta vier `403` com `Your company does not have access to autoApprove payments via API`, use a Opção 2. Veja mais em [Como criar e aprovar um pagamento em uma única chamada?](../payment/payment-how-to-auto-approve.md).
+
+:::
 
 ### Opção 2: aprovação em dois passos
 
@@ -81,7 +87,7 @@ Sem o `autoApprove`, o mesmo `POST /api/v1/payment` cria o pagamento com status 
   "payment": {
     "value": 1,
     "status": "CREATED",
-    "destinationAlias": "07*******61",
+    "destinationAlias": "12345678909",
     "destinationAliasType": "CPF",
     "comment": "request user information",
     "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001",
@@ -106,7 +112,7 @@ curl --location 'https://api.woovi.com/api/v1/payment/approve' \
   "payment": {
     "status": "APPROVED",
     "value": 1,
-    "destinationAlias": "07*******61",
+    "destinationAlias": "12345678909",
     "comment": "request user information",
     "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001",
     "sourceAccountId": "6823414a524ed520d3518dd6"
@@ -114,7 +120,11 @@ curl --location 'https://api.woovi.com/api/v1/payment/approve' \
 }
 ```
 
-> A criação **não** valida a chave: um pagamento para uma chave inexistente é criado normalmente e só falha depois de aprovado. E nenhuma das duas chamadas retorna os dados do titular — o Pix é liquidado de forma assíncrona, então esse dado só existe depois da confirmação. Para obtê-lo, consulte o pagamento (próximo passo).
+:::note
+
+A criação **não** valida a chave: um pagamento para uma chave inexistente é criado normalmente e só falha depois de aprovado. E nenhuma das duas chamadas retorna os dados do titular — o Pix é liquidado de forma assíncrona, então esse dado só existe depois da confirmação. Para obtê-lo, consulte o pagamento (próximo passo).
+
+:::
 
 ## 2. Consulte o pagamento para obter os dados do titular
 
@@ -125,77 +135,77 @@ curl --location 'https://api.woovi.com/api/v1/payment/c0938e0c-a613-48a9-982a-67
   --header 'Authorization: {APP_ID}'
 ```
 
-Exemplo real de resposta (dados sensíveis mascarados abaixo apenas para fins desta documentação — a API não mascara nada, veja a nota logo em seguida):
-
 ```json
 {
   "payment": {
     "status": "CONFIRMED",
     "value": 1,
-    "destinationAlias": "07*******61",
+    "destinationAlias": "12345678909",
     "comment": "request user information",
     "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001",
     "sourceAccountId": "6823414a524ed520d3518dd6"
   },
   "transaction": {
     "value": 1,
-    "time": "2026-08-24T20:11:01.783Z",
-    "endToEndId": "E54811417202608242011RymkUzu7ANw",
+    "time": "2026-01-01T12:00:00.000Z",
+    "endToEndId": "E54811417202601011200abcdefghijk",
     "creditParty": {
       "pixKey": {
-        "pixKey": "07*******61",
+        "pixKey": "12345678909",
         "type": "CPF"
       },
       "account": {
-        "branch": "1",
-        "account": "709*****1",
+        "branch": "0001",
+        "account": "1234567890",
         "accountType": "TRAN"
       },
       "psp": {
-        "id": "37880206",
-        "name": "CORA SCFI"
+        "id": "12345678",
+        "name": "BANCO EXEMPLO S.A."
       },
       "holder": {
-        "name": "LUC** ****** ****",
-        "nameFriendly": "LUC** ****** ****",
+        "name": "Fulano de Tal",
+        "nameFriendly": "Fulano de Tal",
         "taxID": {
-          "taxID": "07*******61",
+          "taxID": "12345678909",
           "type": "BR:CPF"
         }
       }
     }
   },
   "destination": {
-    "name": "LUC** ****** ****",
-    "taxID": "07*******61",
-    "pixKey": "07*******61",
-    "bank": "CORA SCFI",
-    "branch": "1",
-    "account": "709*****1"
+    "name": "Fulano de Tal",
+    "taxID": "12345678909",
+    "pixKey": "12345678909",
+    "bank": "BANCO EXEMPLO S.A.",
+    "branch": "0001",
+    "account": "1234567890"
   }
 }
 ```
 
-> O mascaramento acima (`****`) foi aplicado só nesta documentação — a resposta real da API **não** vem mascarada, traz o `name`/`taxID`/`account` completos, exatamente como resolvidos pelo banco.
-
-- `destination.name` / `destination.taxID` — nome e documento do titular da chave, resolvidos pelo banco do recebedor no momento da liquidação. Diferente de uma validação em que você mesmo informa o nome, aqui o nome vem **do banco**, não do que você enviou.
+- `destination.name` / `destination.taxID` — nome e documento do titular da chave, resolvidos pelo banco do recebedor no momento da liquidação. Diferente de uma validação em que você mesmo informa o nome, aqui o nome vem **do banco**, não do que você enviou. Não vêm mascarados.
 - `destination.pixKey` — a chave Pix usada (`destinationAlias`).
 - `destination.bank` / `branch` / `account` — instituição financeira, agência e conta vinculadas à chave.
 - `transaction.endToEndId` — identificador do Pix no Banco Central, útil para conciliação.
 
-> O bloco `destination` só aparece com o pagamento `CONFIRMED`. Enquanto o status for `CREATED` ou `APPROVED`, a resposta traz apenas o `payment` — a confirmação costuma levar poucos segundos.
+:::note
 
-## 3. Quando a chave não existe ou o pagamento é rejeitado
+O bloco `destination` só aparece com o pagamento `CONFIRMED`. Enquanto o status for `CREATED` ou `APPROVED`, a resposta traz apenas o `payment` — a confirmação costuma levar poucos segundos.
 
-Se a chave não estiver cadastrada em nenhum banco (ou o PSP do recebedor rejeitar o Pix), o pagamento vai para `FAILED`, **sem** `transaction` e **sem** `destination`, e o motivo vem no bloco `error`:
+:::
+
+## 3. Erros possíveis
+
+Se a chave não estiver cadastrada em nenhum banco, ou o PSP do recebedor rejeitar o Pix, o pagamento vai para `FAILED`, **sem** `transaction` e **sem** `destination`, e o motivo vem no bloco `error`. Nesse caso o dinheiro não sai da conta.
 
 ```json
 {
   "payment": {
     "status": "FAILED",
     "value": 1,
-    "destinationAlias": "chave-inexistente@exemplo.com",
-    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0002",
+    "destinationAlias": "12345678909",
+    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001",
     "sourceAccountId": "6823414a524ed520d3518dd6"
   },
   "error": {
@@ -205,9 +215,15 @@ Se a chave não estiver cadastrada em nenhum banco (ou o PSP do recebedor rejeit
 }
 ```
 
-Nesse caso o dinheiro não sai da conta. Quando a rejeição vem do banco do recebedor, o código também aparece em `transaction.providerRejectedReason` — veja a lista em [Error codes - Payment](./error-codes-payment.md).
+- `PIX_KEY_INFO_NOT_FOUND` — chave válida mas não cadastrada no DICT
+- `403 External payments not enabled for your company` — Pix Out não habilitado na empresa
+- `400 External payments not enabled for this account` — Pix Out não habilitado na conta de origem
+- `403 Your company does not have access to autoApprove payments via API` — use a aprovação em dois passos
+- `400 destinationAliasType must be one of the following values` — tipo de chave fora do enum
 
-## 4. Webhooks (opcional)
+Quando a rejeição vem do banco do recebedor, o código também aparece em `transaction.providerRejectedReason` — veja a lista em [Error codes - Payment](./error-codes-payment.md).
+
+## 4. Webhooks
 
 Para não ficar consultando o pagamento em intervalos, configure um webhook e reaja ao evento de confirmação ou de falha. Nenhum dos dois traz os dados do titular — use o `correlationID` deles para consultar o pagamento (passo 2).
 
@@ -224,8 +240,8 @@ Para não ficar consultando o pagamento em intervalos, configure um webhook e re
   },
   "transaction": {
     "value": 1,
-    "time": "2026-08-24T20:11:01.783Z",
-    "endToEndId": "E54811417202608242011RymkUzu7ANw"
+    "time": "2026-01-01T12:00:00.000Z",
+    "endToEndId": "E54811417202601011200abcdefghijk"
   }
 }
 ```
@@ -238,12 +254,12 @@ Para não ficar consultando o pagamento em intervalos, configure um webhook e re
   "payment": {
     "value": 1,
     "status": "FAILED",
-    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0002"
+    "correlationID": "c0938e0c-a613-48a9-982a-672c062d0001"
   },
   "transaction": {
     "value": 1,
-    "endToEndId": "E54811417202608242011RymkUzu7ANw",
-    "time": "2026-08-24T20:11:31.687Z",
+    "endToEndId": "E54811417202601011200abcdefghijk",
+    "time": "2026-01-01T12:00:00.000Z",
     "providerRejectedReason": "AC03 - Pagamento rejeitado pelo PSP do recebedor"
   }
 }


### PR DESCRIPTION
## Why

A customer was pointed at this page and came back asking support to "enable API MASTER" for their account — the page listed API MASTER as a prerequisite, and the app creation screen only offers API REST / Plugin / Oracle. There was nothing to enable: the prerequisite was wrong.

`POST /api/v1/payment` is gated by the `PIX_OUT` company feature (`openPixApiRouter.ts` `hasPixOutFeature`), the source account `withdraw.enablePixOut` flag (`handleMovementCreate.ts`) and the `PAYMENT_POST` scope. `MASTER` only grants account/application creation via API (`accountPost.ts:122`), so a plain `API` AppID is enough.

## What changed

- Prerequisites are now what the code actually checks: an AppID with `PAYMENT_POST` + `PAYMENT_GET`, `PIX_OUT` on the company, and Pix Out allowed on the paying account (self-service, help-center link kept). Added the note that the 1-cent Pix is real and charged.
- Step 2 is now `GET /api/v1/payment/{id}` instead of `GET /api/v1/transaction/{endToEndId}`: the payment GET already returns the holder in the flat `destination` block plus the full `transaction.creditParty`, so the flow needs one endpoint pair and one scope instead of two.
- Documented what the create call really does — it never validates the key (a payment to a nonexistent key is created fine and only fails after approval) and never returns the holder.
- New section for the failure shape: `FAILED` with no `transaction` and no `destination`, reason in `error.code` / `error.description`.
- Webhooks are now framed as the optional way to avoid polling.
- AI prompt updated: `<APP_ID>` instead of `<APP_ID_MASTER>`, payment GET instead of transaction GET, failure handling included.

## Validation

Reproduced end to end against production with a real AppID (type `API`, no MASTER):

| Call | Result |
| --- | --- |
| `POST /payment` `value:1`, `autoApprove:true`, CNPJ key | `200`, `status: APPROVED`, no holder data |
| `GET /payment/{correlationID}` | `CONFIRMED` + `destination` `{name, taxID, pixKey, bank, branch, account}` + full `transaction.creditParty` |
| `GET /transaction/{endToEndId}` | same data, one extra scope (`TRANSACTION_GET`) |
| `POST /payment` to a nonexistent key | `FAILED`, no `transaction`/`destination`, `error.code: PIX_KEY_INFO_NOT_FOUND`, funds not debited |

Webhook event names checked against `packages/webhook/src/webhookEvents.ts` (`OPENPIX:MOVEMENT_CONFIRMED` / `OPENPIX:MOVEMENT_FAILED`).

## Follow-up (not in this PR)

`docs/payment/decode-emv.md` claims the Pix key check returns the `pixKeyEndToEndId` "required to create a payment". In `paymentPost.ts:212` that field is `nullable()` and `getEndToEndId()` generates one when absent, so the check is not required. Happy to fix in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xLLVdYBeJxg96zXF3Micv