### PR TITLE
use the event names the webhooks actually carry

### DIFF
--- a/docs/charge/webhook/charge-webhook-example-charge-completed.md
+++ b/docs/charge/webhook/charge-webhook-example-charge-completed.md
@@ -9,7 +9,7 @@ tags:
 ## Webhook de cobrança paga
 
 Segue abaixo o exemplo dos dados que são enviados numa requisição do webhook de cobrança
-paga (`woovi:CHARGE_COMPLETED`). Esse webhook é disparado no momento que um usuário paga uma cobrança.
+paga (`OPENPIX:CHARGE_COMPLETED`). Esse webhook é disparado no momento que um usuário paga uma cobrança.
 
 - `pix`: Objeto com detalhes da transação Pix relacionada ao pagamento da cobrança;
 - `company`: Empresa do qual a cobrança pertence;
@@ -20,7 +20,7 @@ paga (`woovi:CHARGE_COMPLETED`). Esse webhook é disparado no momento que um usu
 
 ```json
 {
-  "event": "woovi:CHARGE_COMPLETED",
+  "event": "OPENPIX:CHARGE_COMPLETED",
   "charge": {
     "customer": {
       "name": "John Doe",

--- a/docs/charge/webhook/charge-webhook-example-charge-created.md
+++ b/docs/charge/webhook/charge-webhook-example-charge-created.md
@@ -9,7 +9,7 @@ tags:
 ## Webhook de cobrança criada
 
 Segue abaixo o exemplo dos dados que são enviados numa requisição do webhook de cobrança
-paga (`woovi:CHARGE_CREATED`). Esse webhook é disparado no momento em que um usuário cria
+paga (`OPENPIX:CHARGE_CREATED`). Esse webhook é disparado no momento em que um usuário cria
 uma nova cobrança, seja pela API ou pela plataforma.
 
 - `company`: Empresa do qual a cobrança pertence;
@@ -20,7 +20,7 @@ uma nova cobrança, seja pela API ou pela plataforma.
 
 ```json
 {
-  "event": "woovi:CHARGE_CREATED",
+  "event": "OPENPIX:CHARGE_CREATED",
   "charge": {
     "customer": {
       "name": "John Doe",

--- a/docs/charge/webhook/charge-webhook-example-charge-expired.md
+++ b/docs/charge/webhook/charge-webhook-example-charge-expired.md
@@ -9,10 +9,10 @@ tags:
 ## Webhook de cobrança expirada
 
 Segue abaixo o exemplo dos dados que são enviados numa requisição do webhook de
-cobrança expirada (`woovi:CHARGE_EXPIRED`). Esse webhook é disparado no momento
+cobrança expirada (`OPENPIX:CHARGE_EXPIRED`). Esse webhook é disparado no momento
 que a cobrança é expirada.
 
-- `event`: O tipo de evento realizado que neste caso seria `woovi:CHARGE_EXPIRED`.
+- `event`: O tipo de evento realizado que neste caso seria `OPENPIX:CHARGE_EXPIRED`.
 - `charge`: A cobrança que foi expirada.
 - `company`: Empresa a que a cobrança pertence.
 
@@ -20,7 +20,7 @@ que a cobrança é expirada.
 
 ```json
 {
-  "event": "woovi:CHARGE_EXPIRED",
+  "event": "OPENPIX:CHARGE_EXPIRED",
   "charge": {
     "customer": {
       "name": "Antonio Victor",

--- a/docs/checkout/checkout-how-to-identify-a-charge-created-by-checkout-via-webhook.md
+++ b/docs/checkout/checkout-how-to-identify-a-charge-created-by-checkout-via-webhook.md
@@ -48,11 +48,11 @@ Com essas informações, você pode identificar o checkout que originou a cobran
 
 ## Exemplo de payload de webhook
 
-Segue abaixo o payload de exemplo de uma cobrança criada (`woovi:CHARGE_CREATED`) via Checkout:
+Segue abaixo o payload de exemplo de uma cobrança criada (`OPENPIX:CHARGE_CREATED`) via Checkout:
 
 ```json
 {
-  "event": "woovi:CHARGE_CREATED",
+  "event": "OPENPIX:CHARGE_CREATED",
   "charge": {
     "customer": null,
     "value": 1200,

--- a/docs/disputa/webhook-dispute.mdx
+++ b/docs/disputa/webhook-dispute.mdx
@@ -25,7 +25,7 @@ Esse é o webhook que será enviado quando uma disputa for criada
 
 ```json
 {
-  "event": "woovi:DISPUTE_CREATED",
+  "event": "OPENPIX:DISPUTE_CREATED",
   "dispute": {
     "status": "OPENED",
     "endToEndId": "E3524a995bbd54034b6d07c1c36014557",

--- a/docs/ecommerce/easydigitaldownloads/easydigitaldownloads.mdx
+++ b/docs/ecommerce/easydigitaldownloads/easydigitaldownloads.mdx
@@ -54,7 +54,7 @@ Vá até a plataforma e acesse [API/Plugins > Novo Webhook](https://app.woovi.co
 
 ![Página de criação de webhooks](./__assets__/edd-woovi-create-webhook.png)
 
-Informe o nome do webhook, selecione o evento "Cobrança paga - woovi:CHARGE_COMPLETED" e insira a URL do seu webhook de acordo com o que foi informado na página de configurações do plugin seguindo o formato `https://<url-do-seu-site>/wp-json/edd-woovi-gateway-webhook/v1/callback`.
+Informe o nome do webhook, selecione o evento "Cobrança paga - OPENPIX:CHARGE_COMPLETED" e insira a URL do seu webhook de acordo com o que foi informado na página de configurações do plugin seguindo o formato `https://<url-do-seu-site>/wp-json/edd-woovi-gateway-webhook/v1/callback`.
 
 Salve o webhook e sua configuração estará pronta.
 

--- a/docs/flows/error-codes-payment.md
+++ b/docs/flows/error-codes-payment.md
@@ -115,7 +115,7 @@ Quando um pagamento PIX falha, o webhook `MOVEMENT_FAILED` retorna informações
 
 ```json
 {
-  "event": "woovi:MOVEMENT_FAILED",
+  "event": "OPENPIX:MOVEMENT_FAILED",
   "payment": {
     "value": 1,
     "status": "FAILED",

--- a/docs/flows/sandbox-error-simulation.md
+++ b/docs/flows/sandbox-error-simulation.md
@@ -63,7 +63,7 @@ Este é o webhook que você receberá ao usar a conta `1010107` no exemplo acima
 
 ```json
 {
-  "event": "woovi:MOVEMENT_FAILED",
+  "event": "OPENPIX:MOVEMENT_FAILED",
   "payment": {
     "value": 1,
     "status": "FAILED",

--- a/docs/integrations/n8n-without-plugin.md
+++ b/docs/integrations/n8n-without-plugin.md
@@ -110,18 +110,18 @@ O primeiro passo é adicionar um nó "Webhook" ao seu workflow. Este nó será r
 3. Vá para a seção "API/Plugins" e clique em "Novo Webhook"
 4. Garanta que a opção "Ativo" esteja habilitada, dê um nome para o webhook, configure o tipo de evento a ser escutado e cole a URL do webhook do N8N no campo "URL"
 5. Selecione os eventos que você deseja receber notificações. Os eventos disponíveis são:
-   - woovi:CHARGE_CREATED - Nova Cobrança Criada
-   - woovi:CHARGE_COMPLETED - Cobrança Paga
-   - woovi:CHARGE_EXPIRED - Cobrança Expirada
-   - woovi:CHARGE_COMPLETED_NOT_SAME_CUSTOMER_PAYER - Cobrança Paga por Outra Pessoa
-   - woovi:TRANSACTION_RECEIVED - Transação Pix Recebida
-   - woovi:TRANSACTION_REFUND_RECEIVED - Reembolso Concluído
-   - woovi:MOVEMENT_CONFIRMED - Pagamento Externo Confirmado (Pix Out)
-   - woovi:MOVEMENT_FAILED - Pagamento Externo com Falha (Pix Out)
-   - woovi:MOVEMENT_REMOVED - Pagamento Externo Removido (Pix Out)
-   - woovi:DISPUTE_CREATED - Disputa Criada
-   - woovi:DISPUTE_ACCEPTED - Disputa Aceita
-   - woovi:DISPUTE_REJECTED - Disputa Rejeitada
+   - OPENPIX:CHARGE_CREATED - Nova Cobrança Criada
+   - OPENPIX:CHARGE_COMPLETED - Cobrança Paga
+   - OPENPIX:CHARGE_EXPIRED - Cobrança Expirada
+   - OPENPIX:CHARGE_COMPLETED_NOT_SAME_CUSTOMER_PAYER - Cobrança Paga por Outra Pessoa
+   - OPENPIX:TRANSACTION_RECEIVED - Transação Pix Recebida
+   - OPENPIX:TRANSACTION_REFUND_RECEIVED - Reembolso Concluído
+   - OPENPIX:MOVEMENT_CONFIRMED - Pagamento Externo Confirmado (Pix Out)
+   - OPENPIX:MOVEMENT_FAILED - Pagamento Externo com Falha (Pix Out)
+   - OPENPIX:MOVEMENT_REMOVED - Pagamento Externo Removido (Pix Out)
+   - OPENPIX:DISPUTE_CREATED - Disputa Criada
+   - OPENPIX:DISPUTE_ACCEPTED - Disputa Aceita
+   - OPENPIX:DISPUTE_REJECTED - Disputa Rejeitada
 6. Clique em "Salvar"
 
 ![](./__assets__/n8n-without-plugin/webhooks/woovi-create-webhook.png)

--- a/docs/integrations/oneclick.md
+++ b/docs/integrations/oneclick.md
@@ -37,7 +37,7 @@ A primeira chamada será uma teste, para identificar se o seu endpoint existe e 
 {
   "data_criacao": "2023-07-12T13:58:06.821Z",
   "evento": "teste_webhook",
-  "event": "woovi:TRANSACTION_RECEIVED"
+  "event": "OPENPIX:TRANSACTION_RECEIVED"
 }
 ```
 
@@ -54,7 +54,7 @@ curl -X 'POST' \
  -H 'x-woovi-authorization: ' \
  -H 'content-type: application/json' \
  -H 'accept: application/json' \
- -d $'{"data_criacao":"2023-07-12T13:58:06.821Z","evento":"teste_webhook","event":"woovi:TRANSACTION_RECEIVED"}'
+ -d $'{"data_criacao":"2023-07-12T13:58:06.821Z","evento":"teste_webhook","event":"OPENPIX:TRANSACTION_RECEIVED"}'
  ```
 
 #### 4.2. Segunda chamada

--- a/docs/sdk/node/resources.md
+++ b/docs/sdk/node/resources.md
@@ -600,7 +600,7 @@ Para criar um webhook, use o método `create` no recurso de webhook.
 const response = await woovi.webhook.create({
   webhook: {
     name: 'webhookName',
-    event: 'woovi:CHARGE_CREATED',
+    event: 'OPENPIX:CHARGE_CREATED',
     url: 'https://mycompany.com.br/webhook',
     authorization: 'woovi',
     isActive: true,

--- a/docs/sdk/php/frameworks/laravel/receiving-webhooks.md
+++ b/docs/sdk/php/frameworks/laravel/receiving-webhooks.md
@@ -47,7 +47,7 @@ class WebhookController extends Controller
 {
     const SIGNATURE_HEADER = "x-webhook-signature";
 
-    const woovi_CHARGE_COMPLETED_EVENT = "woovi:CHARGE_COMPLETED";
+    const woovi_CHARGE_COMPLETED_EVENT = "OPENPIX:CHARGE_COMPLETED";
 
     public function __construct(private Client $woovi)
     {
@@ -162,14 +162,14 @@ Durante o processamento dos webhooks, é possível validar seus tipos e encaminh
 
 Cada requisição irá trazer consigo um parâmetro `event` contendo o tipo do webhook. Veja algumas possibilidades de valores:
 
-- `woovi:CHARGE_CREATED` - Nova cobrança criada.
-- `woovi:CHARGE_COMPLETED` - Cobrança concluída é quando uma cobrança é totalmente paga.
-- `woovi:CHARGE_EXPIRED` - Cobrança expirada é quando uma cobrança não foi totalmente paga e expirou.
-- `woovi:TRANSACTION_RECEIVED` - Nova transação PIX recebida.
-- `woovi:TRANSACTION_REFUND_RECEIVED` - Novo reembolso de transação PIX recebido ou reembolsado.
-- `woovi:MOVEMENT_CONFIRMED` - Pagamento confirmado é quando a transação do pix referente ao pagamento é confirmada.
-- `woovi:MOVEMENT_FAILED` - Falha no pagamento é quando o pagamento é aprovado e ocorre um erro.
-- `woovi:MOVEMENT_REMOVED` - O pagamento foi removido por um usuário.
+- `OPENPIX:CHARGE_CREATED` - Nova cobrança criada.
+- `OPENPIX:CHARGE_COMPLETED` - Cobrança concluída é quando uma cobrança é totalmente paga.
+- `OPENPIX:CHARGE_EXPIRED` - Cobrança expirada é quando uma cobrança não foi totalmente paga e expirou.
+- `OPENPIX:TRANSACTION_RECEIVED` - Nova transação PIX recebida.
+- `OPENPIX:TRANSACTION_REFUND_RECEIVED` - Novo reembolso de transação PIX recebido ou reembolsado.
+- `OPENPIX:MOVEMENT_CONFIRMED` - Pagamento confirmado é quando a transação do pix referente ao pagamento é confirmada.
+- `OPENPIX:MOVEMENT_FAILED` - Falha no pagamento é quando o pagamento é aprovado e ocorre um erro.
+- `OPENPIX:MOVEMENT_REMOVED` - O pagamento foi removido por um usuário.
 
 Assumindo que você tenha um método `handleWebhook` que recebe todos os webhooks com a assinatura validada, veja o exemplo:
 
@@ -219,10 +219,10 @@ private function isChargePaidPayload(Request $request)
         // Indicam quais eventos são considerados como
         // uma cobrança sendo paga.
 
-        // "woovi:CHARGE_COMPLETED"
+        // "OPENPIX:CHARGE_COMPLETED"
         self::woovi_CHARGE_COMPLETED_EVENT,
         
-        // "woovi:TRANSACTION_RECEIVED"
+        // "OPENPIX:TRANSACTION_RECEIVED"
         self::woovi_TRANSACTION_RECEIVED_EVENT,
     ];
 
@@ -238,7 +238,7 @@ private function isChargePaidPayload(Request $request)
 Ao configurar uma nova integração via webhooks na plataforma, ela enviará um webhook de teste para verificar se tudo está correto com sua aplicação.
 
 Esse webhook de teste será enviado com o campo `event` contendo o valor especificado pelo evento selecionado na plataforma. 
-Por exemplo, se você selecionar o evento `Cobrança paga`, o campo `event` será `woovi:CHARGE_COMPLETED`.
+Por exemplo, se você selecionar o evento `Cobrança paga`, o campo `event` será `OPENPIX:CHARGE_COMPLETED`.
 
 Veja como é possível verificar se um webhook é de teste:
 

--- a/docs/sdk/php/resources.md
+++ b/docs/sdk/php/resources.md
@@ -703,16 +703,16 @@ $webhook = [
     "webhook" => [
         "name" => "webhookName (php-sdk)",
 
-        // Eventos disponíveis para registrar um webhook para ouvir. Se ninguém selecionar ninguém, o evento padrão será woovi:TRANSACTION_RECEIVED.
-        // woovi:CHARGE_CREATED - Nova cobrança criada.
-        // woovi:CHARGE_COMPLETED - Cobrança concluída é quando uma cobrança é totalmente paga.
-        // woovi:CHARGE_EXPIRED - Cobrança expirada é quando uma cobrança não foi totalmente paga e expirou.
-        // woovi:TRANSACTION_RECEIVED - Nova transação PIX recebida.
-        // woovi:TRANSACTION_REFUND_RECEIVED - Novo reembolso de transação PIX recebido ou reembolsado.
-        // woovi:MOVEMENT_CONFIRMED - Pagamento confirmado é quando a transação do pix referente ao pagamento é confirmada.
-        // woovi:MOVEMENT_FAILED - Falha no pagamento é quando o pagamento é aprovado e ocorre um erro.
-        // woovi:MOVEMENT_REMOVED - O pagamento foi removido por um usuário.
-        "event" => "woovi:CHARGE_CREATED",
+        // Eventos disponíveis para registrar um webhook para ouvir. Se ninguém selecionar ninguém, o evento padrão será OPENPIX:TRANSACTION_RECEIVED.
+        // OPENPIX:CHARGE_CREATED - Nova cobrança criada.
+        // OPENPIX:CHARGE_COMPLETED - Cobrança concluída é quando uma cobrança é totalmente paga.
+        // OPENPIX:CHARGE_EXPIRED - Cobrança expirada é quando uma cobrança não foi totalmente paga e expirou.
+        // OPENPIX:TRANSACTION_RECEIVED - Nova transação PIX recebida.
+        // OPENPIX:TRANSACTION_REFUND_RECEIVED - Novo reembolso de transação PIX recebido ou reembolsado.
+        // OPENPIX:MOVEMENT_CONFIRMED - Pagamento confirmado é quando a transação do pix referente ao pagamento é confirmada.
+        // OPENPIX:MOVEMENT_FAILED - Falha no pagamento é quando o pagamento é aprovado e ocorre um erro.
+        // OPENPIX:MOVEMENT_REMOVED - O pagamento foi removido por um usuário.
+        "event" => "OPENPIX:CHARGE_CREATED",
 
         "url" => "https://example.com",
         "authorization" => "woovi-php-sdk",
@@ -732,7 +732,7 @@ $result = $client->webhooks()->create($webhook);
  *         "url" => "https://mycompany.com.br/webhook",
  *         "authorization" => "woovi",
  *         "isActive" => true,
- *         "event" => "woovi:TRANSACTION_RECEIVED",
+ *         "event" => "OPENPIX:TRANSACTION_RECEIVED",
  *         "createdAt" => "2021-03-02T22:29:10.720Z",
  *         "updatedAt" => "2021-03-02T22:29:10.720Z",
  *     ],
@@ -769,7 +769,7 @@ namespace YourIntegration\Http;
  */
 class WebhookHandler
 {
-    const woovi_CHARGE_COMPLETED = "woovi:CHARGE_COMPLETED";
+    const woovi_CHARGE_COMPLETED = "OPENPIX:CHARGE_COMPLETED";
 
     /**
      * Handle an webhook request sent by API.

--- a/docs/sdk/ruby/ruby-sdk-resources.md
+++ b/docs/sdk/ruby/ruby-sdk-resources.md
@@ -197,7 +197,7 @@ response = client.webhooks.fetch_previous_page!
 # Criar um Webhook
 webhook_params = {
   name: "nome do webhook",
-  event: "woovi:CHARGE_CREATED",
+  event: "OPENPIX:CHARGE_CREATED",
   url: "https://meu-endpoint/woovi/webhooks"
 }
 # inicializar o body

--- a/docs/subaccount/how-to-recognize-a-subaccount-of-a-paid-charge.md
+++ b/docs/subaccount/how-to-recognize-a-subaccount-of-a-paid-charge.md
@@ -16,7 +16,7 @@ A forma mais recomendada para reconhecer uma subconta de uma cobrança após o p
 
 ```json
 {
-  "event": "woovi:CHARGE_COMPLETED",
+  "event": "OPENPIX:CHARGE_COMPLETED",
   "charge": {
     "customer": {
       "name": "CONTA DE PAGAMENTO DE PIX",
@@ -144,7 +144,7 @@ A forma mais recomendada para reconhecer uma subconta de uma cobrança após o p
 
 Vamos imaginar um caso que queremos identificar a subconta pertencente a uma cobrança paga, para realizar uma transferência entre subcontas.
 
-Para isso, vamos precisar está criando um Webhook com o evento `Cobrança paga - woovi:CHARGE_COMPLETED`. Para criar esse Webhook, bastar você entrar na nossa plataforma, e acessar a aba `API/Plugins` via sidebar menu.
+Para isso, vamos precisar está criando um Webhook com o evento `Cobrança paga - OPENPIX:CHARGE_COMPLETED`. Para criar esse Webhook, bastar você entrar na nossa plataforma, e acessar a aba `API/Plugins` via sidebar menu.
 
 ![1](./__assets__/how-to-recognize-a-subaccount-of-a-paid-charge-1.png)
 
@@ -157,7 +157,7 @@ Nesse caso, eu vou está criando o Webhook com as seguintes configurações:
 ![3](./__assets__/how-to-recognize-a-subaccount-of-a-paid-charge-3.png)
 
 - Nome: `Webhook de Cobrança Paga` (Você pode está escolhendo o nome que quiser)
-- Evento: `Cobrança paga - woovi:CHARGE_COMPLETED` (Esse evento é disparado quando uma cobrança é paga)
+- Evento: `Cobrança paga - OPENPIX:CHARGE_COMPLETED` (Esse evento é disparado quando uma cobrança é paga)
 - URL: `https://wooviteste.com/webhook` (Essa é a URL do meu serviço que estará recebendo as chamadas do Webhook)
 
 Aqui está um exemplo de um servidor HTTP em Node.js utilizando Express, na qual possui apenas a rota que irá receber as chamadas do Webhook.

--- a/docs/webhook/examples/charge-account-type.mdx
+++ b/docs/webhook/examples/charge-account-type.mdx
@@ -19,7 +19,7 @@ Caso seja uma conta de teste é retornado `"TESTING"` caso seja uma conta de pro
 
 ```json
 {
-  "event": "woovi:CHARGE_COMPLETED",
+  "event": "OPENPIX:CHARGE_COMPLETED",
   "charge": {},
   "pix": {},
   "company": {

--- a/docs/webhook/examples/dispute-accept-payload.mdx
+++ b/docs/webhook/examples/dispute-accept-payload.mdx
@@ -17,7 +17,7 @@ Os webhooks de `Disputa` enviam objetos com os seguintes campos no seu payload:
 
 ```json
 {
-  "event": "woovi:DISPUTE_ACCEPTED",
+  "event": "OPENPIX:DISPUTE_ACCEPTED",
   "dispute": {
     "status": "ACCEPTED",
     "endToEndId": "E3524a995bbd54034b6d07c1c36014557",

--- a/docs/webhook/examples/dispute-canceled-payload.mdx
+++ b/docs/webhook/examples/dispute-canceled-payload.mdx
@@ -17,7 +17,7 @@ Os webhooks de `Disputa` enviam objetos com os seguintes campos no seu payload:
 
 ```json
 {
-  "event": "woovi:DISPUTE_CANCELED",
+  "event": "OPENPIX:DISPUTE_CANCELED",
   "dispute": {
     "status": "CANCELED",
     "endToEndId": "E3524a995bbd54034b6d07c1c36014557",

--- a/docs/webhook/examples/dispute-payload.mdx
+++ b/docs/webhook/examples/dispute-payload.mdx
@@ -23,7 +23,7 @@ Uma disputa `Aberta` é considerada como uma disputa `Criada`
 
 ```json
 {
-  "event": "woovi:DISPUTE_CREATED",
+  "event": "OPENPIX:DISPUTE_CREATED",
   "dispute": {
     "status": "OPENED",
     "endToEndId": "E3524a995bbd54034b6d07c1c36014557",

--- a/docs/webhook/examples/dispute-rejected-payload.mdx
+++ b/docs/webhook/examples/dispute-rejected-payload.mdx
@@ -17,7 +17,7 @@ Os webhooks de `Disputa` enviam objetos com os seguintes campos no seu payload:
 
 ```json
 {
-  "event": "woovi:DISPUTE_REJECTED",
+  "event": "OPENPIX:DISPUTE_REJECTED",
   "dispute": {
     "status": "REJECTED",
     "endToEndId": "E3524a995bbd54034b6d07c1c36014557",

--- a/docs/webhook/examples/idendify-which-api-charge-come.md
+++ b/docs/webhook/examples/idendify-which-api-charge-come.md
@@ -28,7 +28,7 @@ Por exemplo, você pode criar uma cobrança com o `correlationID` igual a `api-1
 
 ```json
 {
-  "event": "woovi:CHARGE_COMPLETED",
+  "event": "OPENPIX:CHARGE_COMPLETED",
   "charge": {
     "value": 1000,
     "correlationID": "api1-1",

--- a/docs/webhook/examples/transaction-received-payload.mdx
+++ b/docs/webhook/examples/transaction-received-payload.mdx
@@ -11,7 +11,7 @@ tags:
 
 Os webhooks do tipo `Transação recebida` enviam objetos com os seguintes campos no seu payload:
 
-- `event`: O tipo de evento realizado que neste caso seria `woovi:CHARGE_EXPIRED`.
+- `event`: O tipo de evento realizado que neste caso seria `OPENPIX:CHARGE_EXPIRED`.
 - `charge`: A cobrança que foi expirada.
 - `type` : Dependendo da transação elas podem vir seguintes tipos: `DYNAMIC` ,`STATIC` ou `PAYMENT`. Onde `PAYMENT` seria o [pix avulso](https://ajuda.woovi.com/hc/duvidas-frequentes/articles/o-que-e-um-pix-avulso). 
 - `company`: Empresa a que a cobrança pertence.

--- a/src/components/WebhookEventExplorer/events.ts
+++ b/src/components/WebhookEventExplorer/events.ts
@@ -713,12 +713,12 @@ const events: WebhookEvent[] = [
   },
   {
     id: 'dispute-created',
-    event: 'woovi:DISPUTE_CREATED',
+    event: 'OPENPIX:DISPUTE_CREATED',
     category: 'Disputa',
     description: 'Disputa criada.',
     docsPath: '/docs/webhook/examples/webhook-created-payload',
     payload: {
-      event: 'woovi:DISPUTE_CREATED',
+      event: 'OPENPIX:DISPUTE_CREATED',
       dispute: {
         status: 'OPENED',
         endToEndId: 'E3524a995bbd54034b6d07c1c36014557',
@@ -732,12 +732,12 @@ const events: WebhookEvent[] = [
   },
   {
     id: 'dispute-accepted',
-    event: 'woovi:DISPUTE_ACCEPTED',
+    event: 'OPENPIX:DISPUTE_ACCEPTED',
     category: 'Disputa',
     description: 'Disputa aceita.',
     docsPath: '/docs/webhook/examples/webhook-accepted-payload',
     payload: {
-      event: 'woovi:DISPUTE_ACCEPTED',
+      event: 'OPENPIX:DISPUTE_ACCEPTED',
       dispute: {
         status: 'ACCEPTED',
         endToEndId: 'E3524a995bbd54034b6d07c1c36014557',
@@ -751,12 +751,12 @@ const events: WebhookEvent[] = [
   },
   {
     id: 'dispute-rejected',
-    event: 'woovi:DISPUTE_REJECTED',
+    event: 'OPENPIX:DISPUTE_REJECTED',
     category: 'Disputa',
     description: 'Disputa rejeitada.',
     docsPath: '/docs/webhook/examples/webhook-rejected-payload',
     payload: {
-      event: 'woovi:DISPUTE_REJECTED',
+      event: 'OPENPIX:DISPUTE_REJECTED',
       dispute: {
         status: 'REJECTED',
         endToEndId: 'E3524a995bbd54034b6d07c1c36014557',
@@ -770,12 +770,12 @@ const events: WebhookEvent[] = [
   },
   {
     id: 'dispute-canceled',
-    event: 'woovi:DISPUTE_CANCELED',
+    event: 'OPENPIX:DISPUTE_CANCELED',
     category: 'Disputa',
     description: 'Disputa cancelada.',
     docsPath: '/docs/webhook/examples/webhook-canceled-payload',
     payload: {
-      event: 'woovi:DISPUTE_CANCELED',
+      event: 'OPENPIX:DISPUTE_CANCELED',
       dispute: {
         status: 'CANCELED',
         endToEndId: 'E3524a995bbd54034b6d07c1c36014557',


### PR DESCRIPTION
## The bug

71 places across 23 files document the webhook `event` field as `woovi:CHARGE_COMPLETED`, `woovi:DISPUTE_CREATED` and so on. **Nothing sends those names.**

`processWebhooks` in the monorepo puts the constant straight into the body:

```ts
payloadApi: { event: eventName, ...payloadApi }
```

and every one of the thirteen names involved is `OPENPIX:` in `packages/webhook/src/webhookEvents.ts`. No repo rewrites the prefix on the way out — `woovi-webhook` contains neither string.

Verified against production rather than by reading code. The `Webhook` collection, 57,637 registrations:

| prefix | registrations |
| --- | --- |
| `OPENPIX:` | 50,899 |
| no prefix (`PIX_AUTOMATIC_*`, `ACCOUNT_REGISTER_*`, …) | 6,738 |
| **`woovi:`** | **0** |

And per event, for the ones this PR touches:

```
OPENPIX:CHARGE_COMPLETED                          18,966
OPENPIX:TRANSACTION_RECEIVED                       8,534
OPENPIX:CHARGE_CREATED                             6,109
OPENPIX:CHARGE_EXPIRED                             4,811
OPENPIX:DISPUTE_CREATED                              877
```

Those are webhooks real customers registered. `woovi:CHARGE_COMPLETED` does not exist in any of the 57k.

## Why it matters

Anyone who follows the docs writes this:

```php
const woovi_CHARGE_COMPLETED_EVENT = "woovi:CHARGE_COMPLETED";
if ($payload['event'] === self::woovi_CHARGE_COMPLETED_EVENT) { ... }
```

The branch never runs. The webhook arrives, the handler answers 200, and the integrator concludes nothing was sent — silent on both sides. It hits the most-used events hardest: 15 of the 71 occurrences are `CHARGE_COMPLETED`.

It reads like the OpenPix → Woovi rebrand find-and-replace reaching the event *values*.

## What changed

`woovi:X` → `OPENPIX:X` in the thirteen affected names. Where it matters most:

- **SDK docs** — `sdk/php/resources.md`, `sdk/php/frameworks/laravel/receiving-webhooks.md`, `sdk/node/resources.md`, `sdk/ruby/ruby-sdk-resources.md`: copy-paste sources;
- **payload examples** — `webhook/examples/*`, `charge/webhook/*`;
- **the event explorer** — `src/components/WebhookEventExplorer/events.ts`, the page where you pick an event and copy the JSON / TypeScript / JSON Schema / Yup / Zod;
- integrations: n8n, oneclick, easydigitaldownloads, sandbox error simulation.

Only values change. The pattern requires the colon, so identifiers like `const woovi_CHARGE_COMPLETED_EVENT` are untouched — visible in the diff: the constant keeps its name, the string changes.

## Checks

No `woovi:<EVENT>` left anywhere in the repo. `events.ts` still loads: 29 events, 0 with a `woovi:` prefix, the four dispute entries now `OPENPIX:DISPUTE_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RubjdcR9rED29TtG3rLEJ