### PR TITLE
resolve API reference links from the spec instead of writing them

### DIFF
--- a/docs/boleto/boleto-out-api.md
+++ b/docs/boleto/boleto-out-api.md
@@ -95,14 +95,14 @@ A resposta traz os dados do boleto:
 
 Se o código for inválido, a API responde `400` com o detalhe do erro.
 
-📖 Endpoint completo na **[Referência da API — Validar boleto](</api#tag/boleto/POST/api/v1/boleto/validate>)**.
+📖 Endpoint completo na **<ApiLink method="POST" path="/api/v1/boleto/validate">Referência da API — Validar boleto</ApiLink>**.
 
 ---
 
 ## 2. Criar o pagamento
 
 Com o boleto validado, crie o pagamento no endpoint
-[Create Payment request](</api#tag/payment-request-access/POST/api/v1/payment>).
+<ApiLink method="POST" path="/api/v1/payment">Create Payment request</ApiLink>.
 Para pagar um boleto, use `type: "BOLETO"` e informe o **`boletoBarcode`**:
 
 | Campo | Obrigatório | Descrição |
@@ -199,7 +199,7 @@ aprovação automática é sempre feita na criação.
 
 Quando o pagamento foi criado sem `autoApprove`, ele fica em `CREATED` e você o
 aprova em uma segunda chamada, enviando o `correlationID`
-([Approve a Payment Request](</api#tag/payment-request-access/POST/api/v1/payment/approve>)).
+(<ApiLink method="POST" path="/api/v1/payment/approve">Approve a Payment Request</ApiLink>).
 
 ```bash
 curl --request POST \
@@ -268,6 +268,6 @@ Os endpoints usados neste guia, na Referência da API:
 
 | Passo | Endpoint | Referência |
 | --- | --- | --- |
-| 1. Validar | `POST /api/v1/boleto/validate` | [Validar boleto](</api#tag/boleto/POST/api/v1/boleto/validate>) |
-| 2. Criar | `POST /api/v1/payment` | [Create Payment request](</api#tag/payment-request-access/POST/api/v1/payment>) |
-| 3. Aprovar | `POST /api/v1/payment/approve` | [Approve a Payment Request](</api#tag/payment-request-access/POST/api/v1/payment/approve>) |
+| 1. Validar | `POST /api/v1/boleto/validate` | <ApiLink method="POST" path="/api/v1/boleto/validate">Validar boleto</ApiLink> |
+| 2. Criar | `POST /api/v1/payment` | <ApiLink method="POST" path="/api/v1/payment">Create Payment request</ApiLink> |
+| 3. Aprovar | `POST /api/v1/payment/approve` | <ApiLink method="POST" path="/api/v1/payment/approve">Approve a Payment Request</ApiLink> |

--- a/docs/cashback/cashback-apis.md
+++ b/docs/cashback/cashback-apis.md
@@ -11,7 +11,7 @@ tags:
 
 Para dar cashback para um cliente via API, você utiliza o _endpoint_ `/api/v1/cashback-fidelity` da API.
 
-Você pode acessar [aqui](/api#tag/cashback-fidelity/POST/api/v1/cashback-fidelity)
+Você pode acessar <ApiLink method="POST" path="/api/v1/cashback-fidelity">aqui</ApiLink>
 a documentação referente a esse _endpoint_.
 
 Os campos obrigatórios para dar um cashback são os sequintes:
@@ -29,7 +29,7 @@ Obs.: O cliente precisa já ter sido criado na plataforma.
 
 Para verificar o saldo de cashback para um cliente via API, você utiliza o _endpoint_ `/api/v1/cashback-fidelity/balance/:cpf-cnpj` da API.
 
-Você pode acessar [aqui](/api#tag/cashback-fidelity/GET/api/v1/cashback-fidelity/balance/{taxID})
+Você pode acessar <ApiLink method="GET" path="/api/v1/cashback-fidelity/balance/{taxID}">aqui</ApiLink>
 a documentação referente a esse _endpoint_.
 
 [`/api/v1/cashback-fidelity/balance/{taxID}`](/api#tag/cashback-fidelity/GET/api/v1/cashback-fidelity/balance/{taxID})

--- a/docs/flows/validate-bank-data-manual.md
+++ b/docs/flows/validate-bank-data-manual.md
@@ -17,7 +17,7 @@ A validação é feita iniciando um pagamento de 1 centavo para a conta informad
 
 ## 1. Crie o pagamento
 
-Crie o pagamento informando os dados bancários do beneficiário, seguindo os parâmetros do endpoint [Create Payment request](</api#tag/payment-request-access/POST/api/v1/payment>).
+Crie o pagamento informando os dados bancários do beneficiário, seguindo os parâmetros do endpoint <ApiLink method="POST" path="/api/v1/payment">Create Payment request</ApiLink>.
 
 ### Campos do pagamento manual
 
@@ -59,7 +59,7 @@ Representa a instituição financeira que processará o pagamento.
 | id    | Identificador único do PSP (código ISPB)        |
 | name  | Nome da instituição financeira (ex: "WOOVI IP") |
 
-Para descobrir o `id` do PSP, consulte o endpoint [PSPs](</api#tag/psp/GET/api/v1/psp>) e use o ISPB no campo `psp.id`.
+Para descobrir o `id` do PSP, consulte o endpoint <ApiLink method="GET" path="/api/v1/psp">PSPs</ApiLink> e use o ISPB no campo `psp.id`.
 
 ```bash
 curl --location 'https://api.woovi.com/api/v1/payment' \
@@ -128,7 +128,7 @@ curl --location 'https://api.woovi.com/api/v1/payment' \
 
 ### Opção 2: Aprovação em dois passos (`/payment/approve`)
 
-Sem o `autoApprove`, o pagamento é criado com status `CREATED` e você precisa aprová-lo em uma segunda chamada, seguindo o endpoint [Approve a Payment Request](</api#tag/payment-request-access/POST/api/v1/payment/approve>).
+Sem o `autoApprove`, o pagamento é criado com status `CREATED` e você precisa aprová-lo em uma segunda chamada, seguindo o endpoint <ApiLink method="POST" path="/api/v1/payment/approve">Approve a Payment Request</ApiLink>.
 
 ```bash
 curl --location 'https://api.woovi.com/api/v1/payment/approve' \
@@ -145,7 +145,7 @@ curl --location 'https://api.woovi.com/api/v1/payment/approve' \
 
 Os dados do titular da conta vêm no campo `destination`. Como o Pix é enviado de forma assíncrona, esse campo **não** está na resposta imediata do `autoApprove` nem nos webhooks — o webhook [`OPENPIX:MOVEMENT_CONFIRMED`](#3-webhooks) avisa apenas que o pagamento foi confirmado, sem trazer os dados do titular.
 
-Para obter o `destination`, consulte o endpoint [`GET /api/v1/transaction`](</api#tag/transactions/GET/api/v1/transaction>) após a confirmação do pagamento, filtrando pela transação correspondente (por exemplo, pelo `endToEndId` recebido no webhook).
+Para obter o `destination`, consulte o endpoint <ApiLink method="GET" path="/api/v1/transaction">`GET /api/v1/transaction`</ApiLink> após a confirmação do pagamento, filtrando pela transação correspondente (por exemplo, pelo `endToEndId` recebido no webhook).
 
 ```json
 {
@@ -210,7 +210,7 @@ Após a criação e confirmação do pagamento, você receberá webhooks com o s
 }
 ```
 
-> Este webhook **não** traz os dados do titular da conta (`destination`). Para obtê-los, consulte o endpoint [`GET /api/v1/transaction`](</api#tag/transactions/GET/api/v1/transaction>) — veja [O que é retornado](#o-que-é-retornado-).
+> Este webhook **não** traz os dados do titular da conta (`destination`). Para obtê-los, consulte o endpoint <ApiLink method="GET" path="/api/v1/transaction">`GET /api/v1/transaction`</ApiLink> — veja [O que é retornado](#o-que-é-retornado-).
 
 Se não souber como configurar o webhook, acesse: [Criando um webhook para interceptar um Pix e chamar uma API](/docs/webhook/platform/webhook-platform-api).
 

--- a/docs/flows/validate-bank-data.md
+++ b/docs/flows/validate-bank-data.md
@@ -19,7 +19,7 @@ A validação é feita enviando um pagamento de 1 centavo para a chave informada
 
 ## 1. Crie e aprove o pagamento
 
-Crie o pagamento informando a chave Pix do beneficiário, seguindo os parâmetros do endpoint [Create Payment request](</api#tag/payment-request-access/POST/api/v1/payment>).
+Crie o pagamento informando a chave Pix do beneficiário, seguindo os parâmetros do endpoint <ApiLink method="POST" path="/api/v1/payment">Create Payment request</ApiLink>.
 
 ### Campos do pagamento por chave Pix
 
@@ -96,7 +96,7 @@ Sem o `autoApprove`, o mesmo `POST /api/v1/payment` cria o pagamento com status 
 }
 ```
 
-Aprove em uma segunda chamada, seguindo o endpoint [Approve a Payment Request](</api#tag/payment-request-access/POST/api/v1/payment/approve>). Essa chamada exige o escopo `PAYMENT_APPROVE_POST` no AppID e envia apenas o `correlationID`.
+Aprove em uma segunda chamada, seguindo o endpoint <ApiLink method="POST" path="/api/v1/payment/approve">Approve a Payment Request</ApiLink>. Essa chamada exige o escopo `PAYMENT_APPROVE_POST` no AppID e envia apenas o `correlationID`.
 
 ```bash
 curl --location 'https://api.woovi.com/api/v1/payment/approve' \
@@ -128,7 +128,7 @@ A criação **não** valida a chave: um pagamento para uma chave inexistente é 
 
 ## 2. Consulte o pagamento para obter os dados do titular
 
-Consulte [`GET /api/v1/payment/{id}`](</api#tag/payment-request-access/GET/api/v1/payment/{id}>) usando o `correlationID` que você enviou. Depois que o pagamento fica `CONFIRMED`, a resposta traz os dados do titular da chave no bloco **`destination`** (e os mesmos dados, completos, em `transaction.creditParty`).
+Consulte <ApiLink method="GET" path="/api/v1/payment/{id}">`GET /api/v1/payment/{id}`</ApiLink> usando o `correlationID` que você enviou. Depois que o pagamento fica `CONFIRMED`, a resposta traz os dados do titular da chave no bloco **`destination`** (e os mesmos dados, completos, em `transaction.creditParty`).
 
 ```bash
 curl --location 'https://api.woovi.com/api/v1/payment/c0938e0c-a613-48a9-982a-672c062d0001' \

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -305,6 +305,9 @@ module.exports = {
             spec: './static/swaggers/bacen-dict.json',
           },
           {
+            // `id` names the plugin instance whose global data <ApiLink> reads;
+            // without it the id is positional (`plugin-redoc-<index>`).
+            id: 'woovi',
             route: '/api-redoc/',
             spec: 'https://api.woovi.com/api/openapi.json',
           },

--- a/src/components/ApiLink/index.tsx
+++ b/src/components/ApiLink/index.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import { usePluginData } from '@docusaurus/useGlobalData';
+
+/**
+ * Links into the API reference without anyone writing the URL.
+ *
+ * The anchor is Scalar's, and it embeds the tag slug — presentation, not
+ * contract — so a renamed or merged tag silently breaks a hand-written link.
+ * Resolving it from the spec at build time makes that a no-op, and an operation
+ * that no longer exists fails the build instead of shipping a dead link.
+ *
+ *   <ApiLink method="POST" path="/api/v1/payment">Create a Payment Request</ApiLink>
+ *   <ApiLink webhook="OPENPIX:CHARGE_COMPLETED">Charge completed</ApiLink>
+ */
+
+// Scalar's own slug: lowercase, drop the characters in its punctuation class,
+// spaces to hyphens. `payment (request access)` -> `payment-request-access`.
+const slugify = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[\0-\x1F!-,./:-@[-^`{-\xA9]/g, '')
+    .replace(/ /g, '-');
+
+type SpecOperation = { tags?: string[] };
+type Spec = {
+  paths?: Record<string, Record<string, SpecOperation>>;
+  webhooks?: Record<string, Record<string, SpecOperation>>;
+};
+
+type Props = {
+  /** HTTP method of the operation, with `path`. */
+  method?: string;
+  /** Path exactly as the spec declares it, e.g. `/api/v1/payment/{id}`. */
+  path?: string;
+  /** Webhook event name, e.g. `OPENPIX:CHARGE_COMPLETED`. */
+  webhook?: string;
+  children: React.ReactNode;
+};
+
+export default function ApiLink({ method, path, webhook, children }: Props) {
+  const data = usePluginData('docusaurus-plugin-redoc', 'woovi') as
+    | { spec?: Spec }
+    | undefined;
+  const spec = data?.spec;
+
+  const target = webhook ? spec?.webhooks?.[webhook]?.post : spec?.paths?.[path]?.[method?.toLowerCase()];
+  const describe = webhook ?? `${method?.toUpperCase()} ${path}`;
+
+  if (!spec) {
+    throw new Error(
+      '<ApiLink>: the woovi spec is not in the build. Does the redocusaurus entry still carry `id: woovi`?',
+    );
+  }
+
+  if (!target?.tags?.length) {
+    throw new Error(`<ApiLink>: ${describe} is not in the served spec`);
+  }
+
+  const tag = slugify(target.tags[0]);
+  const anchor = webhook
+    ? `#tag/${tag}/webhook/POST/${slugify(webhook)}`
+    : `#tag/${tag}/${method.toUpperCase()}${path}`;
+
+  return <Link to={useBaseUrl(`/api${anchor}`)}>{children}</Link>;
+}

--- a/src/theme/MDXComponents.tsx
+++ b/src/theme/MDXComponents.tsx
@@ -1,0 +1,8 @@
+import MDXComponents from '@theme-original/MDXComponents';
+import ApiLink from '@site/src/components/ApiLink';
+
+// Available in every doc without an import, so migrating a page is one edit.
+export default {
+  ...MDXComponents,
+  ApiLink,
+};


### PR DESCRIPTION
Stacked on #761 — GitHub retargets this to `main` when that merges.

## Why

The anchor into the reference embeds the tag slug, and a tag is presentation rather than contract. Rename one, merge two groups, or move an operation between them, and every hand-written link breaks with nothing to report it. That is how 58 links ended up carrying Redoc's format on a page rendered by Scalar, for long enough that nobody remembered.

#760 and #761 fixed the instances. This removes the class.

## What it does

`<ApiLink>` takes what *is* contract — method and path, or a webhook event name — and derives the rest at build time from the spec the redocusaurus plugin already fetched from `api.woovi.com`:

```mdx
<ApiLink method="POST" path="/api/v1/payment">Create a Payment Request</ApiLink>
<ApiLink webhook="OPENPIX:CHARGE_COMPLETED">Charge completed</ApiLink>
```

Verified in this build, on a real page:

```
/api#tag/payment-request-access/POST/api/v1/payment
/api#tag/payment-request-access/POST/api/v1/payment/approve
/api#tag/payment-request-access/GET/api/v1/payment/{id}
```

An operation that is not in the spec **fails the build**, naming the page and the operation:

```
Docusaurus static site generation failed for 1 paths:
  - "/link-probe"
  [cause]: <ApiLink>: POST /api/v1/payment is not in the served spec
```

That is the check `onBrokenAnchors` cannot give. I tried it: the target lives in a client-rendered page, so Docusaurus reported all four correct anchors as broken. `throw` there would fail the build on working links.

## Webhooks are the case that settles it

entria/woovi-openapi#72 brings 36 webhooks. Scalar's anchor for one is `<tag>/webhook/<METHOD>/<slug(name)>`, and its slug drops the colon:

```
OPENPIX:CHARGE_COMPLETED  ->  #tag/webhook/webhook/POST/openpixcharge_completed
```

Nobody writes that by hand thirty-six times. The component already handles it — tested against the 3.1 spec from that PR.

## What was ruled out, and why

- **`onBrokenAnchors: 'throw'`** — false positives on exactly these links, measured.
- **Scalar's own `generateOperationSlug`** — reading their bundle, the operation id is always `<tagPrefix>/<slug>` and the hook only replaces what comes after. Even keyed on `operationId`, a renamed tag still breaks it.
- **`docusaurus-plugin-openapi-docs`** — the ecosystem's answer, and a real option later. It is a migration: 125 operations become pages and the reference URLs change. This component is compatible with going there — where the doc points is now separate from how the reference is rendered, so that move becomes one file rather than 181 edits.

## Scope

Five pages, sixteen links, to prove the mechanism in production. The remaining ~165 follow mechanically in a second PR, with the same dry-run-and-review the earlier ones had.

Registered through `src/theme/MDXComponents.tsx` so migrating a page is one edit rather than an edit plus an import. `id: 'woovi'` names the plugin instance whose global data it reads — without it the id is positional (`plugin-redoc-<index>`).

## Checks

`pnpm build --locale en` SUCCESS on this branch. Worth noting for review: #761 needed a fix that only a real build caught, so this was built rather than script-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RubjdcR9rED29TtG3rLEJ