### PR TITLE
repair the five reference links #761 mangled

### DIFF
--- a/docs/payment/payment-how-to-use-api-to-approve-a-payment.md
+++ b/docs/payment/payment-how-to-use-api-to-approve-a-payment.md
@@ -12,7 +12,7 @@ tags:
 
 Nós disponibilizamos o _endpoint_ `/api/v1/payment/approve` para que você possa approvar um pagamento criado a partir da sua respectiva empresa filiada
 
-Você pode acessar [aqui]([/api#tag/payment-request-access)/paths/~1api~1v1~1payment~1approve/post](/api#tag/payment-request-access)/paths/~1api~1v1~1payment~1approve/post))
+Você pode acessar <ApiLink method="POST" path="/api/v1/payment/approve">aqui</ApiLink>
 a documentação referente a esse _endpoint_.
 
 Como parte do `body` da requisição, esperamos o envio dos seguintes itens: `correlationID`:

--- a/docs/sdk/php/resources.md
+++ b/docs/sdk/php/resources.md
@@ -465,7 +465,7 @@ $client->payments();
 
 Crie uma solicitação de pagamento chamando o método `create` no recurso de pagamentos.
 
-[Documentação do endpoint para mais detalhes]([/api#tag/payment-request-access)/paths/~1api~1v1~1payment/post](/api#tag/payment-request-access)/paths/~1api~1v1~1payment/post)).
+<ApiLink method="POST" path="/api/v1/payment">Documentação do endpoint para mais detalhes</ApiLink>.
 
 ```php
 $payment = [
@@ -508,7 +508,7 @@ $result = $client->payments()->create($payment);
 
 Chame o método `getOne` no recurso de pagamentos para obter uma solicitação de pagamento a partir de um ID de pagamento ou correlationID.
 
-[Documentação do endpoint para mais detalhes]([/api#tag/payment-request-access)/paths/~1api~1v1~1payment~1%7Bid%7D/get](/api#tag/payment-request-access)/paths/~1api~1v1~1payment~1%7Bid%7D/get)).
+<ApiLink method="GET" path="/api/v1/payment/{id}">Documentação do endpoint para mais detalhes</ApiLink>.
 
 ```php
 $paymentOrCorrelationID = "id";
@@ -548,7 +548,7 @@ $result = $client->payments()->getOne($paymentOrCorrelationID);
 
 Chame o método `list` no recurso de pagamentos passando parâmetros de consulta que irá retornar um paginador com pagamentos:
 
-[Documentação do endpoint para mais detalhes]([/api#tag/payment-request-access)/paths/~1api~1v1~1payment/get](/api#tag/payment-request-access)/paths/~1api~1v1~1payment/get)).
+<ApiLink method="GET" path="/api/v1/payment">Documentação do endpoint para mais detalhes</ApiLink>.
 
 ```php
 $paginator = $client->payments()->list();

--- a/docs/subaccount/how-to-get-balance-and-detais-of-subaccount-using-api.mdx
+++ b/docs/subaccount/how-to-get-balance-and-detais-of-subaccount-using-api.mdx
@@ -16,7 +16,7 @@ Para a utilização desta funcionalidade é necessário possuir a funcionalidade
 
 Para acessar o saldo e detalhes de uma subconta, você utiliza o _endpoint_ `/api/v1/subaccount/{ID}` da API.
 
-Você pode acessar [aqui]([/api#tag/subaccount)/paths/~1api~1v1~1subaccount~1%7Bid%7D/get](/api#tag/subaccount)/paths/~1api~1v1~1subaccount~1%7Bid%7D/get))
+Você pode acessar <ApiLink method="GET" path="/api/v1/subaccount/{id}">aqui</ApiLink>
 a documentação referente a esse _endpoint_.
 
 A chave pix registrada na subconta deve ser passada na url da requisição como parâmetro.


### PR DESCRIPTION
My regression, found while auditing what `onBrokenLinks` is hiding.

These five were markdown links nested inside another — `[label]([url](url))` — a shape the pattern in #761 did not match. Stripping the host from the inner copy left a stray bracket and the paren from the old tag slug:

```
[aqui]([/api#tag/subaccount)/paths/~1api~1v1~1subaccount~1%7Bid%7D/get](/api#tag/subaccount)/...))
```

Docusaurus reported it as a broken link to `%5B/api#tag/subaccount` — `%5B` being the `[`. I fixed one instance of this shape in #761, but only the variant wrapped in angle brackets; these five were not.

## The fix

They are `<ApiLink>` now, which is both the repair and the migration — method and path resolve against the served spec at build time, so the same mangling cannot recur:

```mdx
Você pode acessar <ApiLink method="GET" path="/api/v1/subaccount/{id}">aqui</ApiLink>
<ApiLink method="POST" path="/api/v1/payment">Documentação do endpoint para mais detalhes</ApiLink>
```

Each of the five targets is written out and asserted against the spec rather than pattern-matched. A guessy pattern is what caused this.

## Effect

Broken links go from 28 to 25 — the five occurrences produced three reports, since two files repeated the same target. The remaining 23, plus 2 false positives from building a single locale (`/en/api` exists in a full build; verified 200 in production), are pre-existing and unrelated to any of this work.

`pnpm build --locale en`: SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RubjdcR9rED29TtG3rLEJ