### PR TITLE
recompute the reference tag at build time

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,5 +1,6 @@
 import { themes } from 'prism-react-renderer';
 import mdxMermaid from 'mdx-mermaid';
+import remarkApiRefLinks from './plugins/remarkApiRefLinks.mjs';
 
 const lightCodeTheme = themes.github;
 const darkCodeTheme = themes.dracula;
@@ -279,7 +280,13 @@ module.exports = {
             return `https://github.com/Open-Pix/woovi-developers/edit/main/${versionDocsDirPath}/${docPath}`;
           },
           editCurrentVersion: true,
-          remarkPlugins: [mdxMermaid],
+          remarkPlugins: [
+            mdxMermaid,
+            [
+              remarkApiRefLinks,
+              { specUrl: 'https://api.woovi.com/api/openapi.json' },
+            ],
+          ],
         },
         // "blog": {
         //   "path": "blog"

--- a/plugins/remarkApiRefLinks.mjs
+++ b/plugins/remarkApiRefLinks.mjs
@@ -1,0 +1,75 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * Keeps links into the API reference pointing at the right place.
+ *
+ * The Scalar anchor embeds the tag slug, and a tag is presentation rather than
+ * contract — it has been renamed twice here, both times for access gating, and
+ * both times every doc link to it went stale in silence. Method and path are in
+ * the anchor though, so the current tag can be looked up in the served spec and
+ * written in at build time.
+ *
+ * The tag in the link is ignored and recomputed:
+ *
+ *   [label](/api#tag/<anything>/GET/api/v1/payment/{id})
+ *
+ * An operation the served spec does not have fails the build.
+ *
+ * Webhook events are deliberately not handled yet. Their anchor carries a lossy
+ * slug of the event name (`OPENPIX:CHARGE_COMPLETED` -> `openpixcharge_completed`),
+ * which needs a reverse index of the spec — and the served spec has no
+ * `webhooks` section until entria/woovi-openapi#72 ships and a release goes out,
+ * so that path cannot be exercised yet.
+ */
+
+const STRIP = /[\0-\x1F!-,./:-@[-^`{-\xA9]/g;
+const slugify = (value) => value.toLowerCase().replace(STRIP, '').replace(/ /g, '-');
+
+const METHODS = 'GET|POST|PUT|PATCH|DELETE';
+const REFERENCE = new RegExp(`^(/(?:en/)?api)#tag/[^/]+/(${METHODS})(/.*)$`);
+
+let pending;
+
+const loadSpec = (specUrl) => {
+  pending ??= fetch(specUrl).then(async (res) => {
+    if (!res.ok) {
+      throw new Error(`remarkApiRefLinks: ${specUrl} answered ${res.status}`);
+    }
+    return res.json();
+  });
+
+  return pending;
+};
+
+export default function remarkApiRefLinks({ specUrl }) {
+  return async (tree, file) => {
+    const links = [];
+
+    visit(tree, 'link', (node) => {
+      if (typeof node.url !== 'string') {
+        return;
+      }
+      if (REFERENCE.test(node.url)) {
+        links.push(node);
+      }
+    });
+
+    if (!links.length) {
+      return;
+    }
+
+    const spec = await loadSpec(specUrl);
+    const where = file?.path ?? '<unknown file>';
+
+    for (const node of links) {
+      const [, base, method, path] = REFERENCE.exec(node.url);
+      const operation = spec.paths?.[path]?.[method.toLowerCase()];
+
+      if (!operation?.tags?.length) {
+        throw new Error(`remarkApiRefLinks: ${where} links to ${method} ${path}, which the served spec does not have`);
+      }
+
+      node.url = `${base}#tag/${slugify(operation.tags[0])}/${method}${path}`;
+    }
+  };
+}


### PR DESCRIPTION
Stacked on #764. GitHub retargets this to `main` as the stack merges.

## The problem is real, and here is the receipt

The Scalar anchor embeds the tag slug, and a tag is presentation, not contract. It has been renamed twice in these repos and **both times every doc link to it went stale in silence**:

| rename | when |
| --- | --- |
| `pixKey` → `pixKey check (request access)` (entria/woovi-openapi@c7fadcc, #55) | five days ago |
| `sub account (request access)` removed (woovi@6208aec, #81699) | earlier |

Both were access gating, which will keep happening. And both left broken links that had to be found by hand this week — `#tag/pixKey` pointing at endpoints that had moved to another tag, and `#tag/sub-account-(request-access)` pointing at a tag that no longer exists.

Two out of two renames caused this. It is not a hypothetical.

## What this does

Method and path are already in the anchor, so the tag does not have to be trusted. The plugin reads them, looks the operation up in the served spec, and writes the current tag in. An operation the spec does not have fails the build, naming the file.

**Nothing in the docs changes.** All 181 existing links keep their exact current form and start self-healing. That is the whole point: no migration — unlike #762, which protects only the pages it has been applied to, and which needs 165 more edits to finish.

## Verified

Planted the pre-rename tag and built:

```
source  /api#tag/pixkey/POST/api/v1/pix-keys/check
built   /api#tag/pixkey-check-request-access/POST/api/v1/pix-keys/check
```

`pnpm build --locale pt-BR` SUCCESS, with `onBrokenLinks: 'throw'` from #764 already on.

The config is a plain object, so the spec cannot be fetched while it loads. Remark transformers can be async, so the plugin fetches once on the first page carrying a link and caches it — the same `api.woovi.com` fetch redocusaurus already makes.

## Left out on purpose

**An authoring form.** `[label](#api/GET/api/v1/payment/{id})` — naming the operation and never a slug — would mean nothing in the source can rot. It did not resolve when I tried it and I removed it rather than ship it unverified. Worth revisiting.

**Webhook events.** Their anchor carries a lossy slug of the event name (`OPENPIX:CHARGE_COMPLETED` → `openpixcharge_completed`), so it needs a reverse index of the spec. I checked the 36 events from entria/woovi-openapi#72: 36 distinct slugs, no collision, so it works in principle. But the served spec has no `webhooks` section until that PR ships **and a release goes out** — the plugin reads production, so the merge alone is not enough. That path follows once it can actually be exercised.

## On #762

If this merges, the `<ApiLink>` component is largely redundant: this covers every link, in markdown, with no migration. Reverting it or keeping it only for webhooks are both reasonable — I introduced it, and this is the better shape for the same problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RubjdcR9rED29TtG3rLEJ