### PR TITLE
docs(kyc-validation): trim the taxId POST description in the API explorer

### DIFF
--- a/src/components/ApiExplorer/endpoints.ts
+++ b/src/components/ApiExplorer/endpoints.ts
@@ -1445,7 +1445,7 @@ const endpoints: ApiEndpoint[] = [
     'tag': 'kyc',
     'category': 'KYC',
     'summary': 'Create a KYC validation for a Tax ID',
-    'description': "Screens a CPF or CNPJ against fraud, dispute, sanctions, PEP and lawsuit signals and\nreturns a verdict.\n\nThe screening runs asynchronously: this call answers `201` with `status: PROCESSING`,\nand the verdict is read back with `GET /api/v1/kyc-validation/{correlationID}`\n(usually ready in well under a second) or received through the\n`KYC_VALIDATION_COMPLETED` / `KYC_VALIDATION_FAILED` webhook events.\n\n**Idempotent by `correlationID`.** Sending the same `correlationID` again returns the\noriginal validation with `200` and is not billed a second time. A new `correlationID`\nis a new billable validation — including a retry after a `FAILED` one.\n\nEach validation is charged as `KYC_VALIDATION_FEE`, priced from the account's\n`kycValidationFeeSettings`, and the charge happens **before** the screening is queued:\na validation that answers `201` has already been billed.\n\nRequires the `KYC_VALIDATION` feature on the company and the `KYC_VALIDATION_POST`\nscope on the application.\n",
+    'description': 'Screens a CPF or CNPJ against fraud, dispute, sanctions, PEP and lawsuit signals and\nreturns a verdict.\n\nRequires the `KYC_VALIDATION` feature on the company and the `KYC_VALIDATION_POST`\nscope on the application.\n',
     'requestExamples': [
       {
         'name': 'cnpj',


### PR DESCRIPTION
Portal mirror of **entria/woovi-openapi#75**: the `POST /api/v1/kyc-validation/taxid` card in the API Explorer drops the five paragraphs of async/idempotency/billing mechanics and keeps only what a caller needs before the call —

> Screens a CPF or CNPJ against fraud, dispute, sanctions, PEP and lawsuit signals and returns a verdict.
>
> Requires the `KYC_VALIDATION` feature on the company and the `KYC_VALIDATION_POST` scope on the application.

The detail that came out is still on the response bodies and in `docs/flows/kyc-validation.md`.

### Why the base is `docs/kyc-validation` and not `main`

The endpoint itself only exists on #755, which is still open — there is nothing on `main` to trim yet. This stacks on that branch so the diff is a single line; it should merge after #755.

### Note for #755

`main` has since dropped `src/swaggers/woovi.json` and `static/swaggers/woovi.json` (`feat(api): read the spec from api.woovi.com instead of a copy`), and #755 still edits both — expect a modify/delete conflict there. That is why this PR only touches `endpoints.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)