### PR TITLE
docs(stablecoin): explain what happens when a settled payout comes back

### DIFF
--- a/docs/stablecoin/stablecoin-payout-flow.md
+++ b/docs/stablecoin/stablecoin-payout-flow.md
@@ -65,6 +65,8 @@ flowchart LR
 5. Configure os [webhooks](./stablecoin-webhooks.md):
    - `STABLECOIN_PAYOUT_COMPLETED`
    - `STABLECOIN_PAYOUT_FAILED`
+   - `STABLECOIN_PAYOUT_REFUND_CONFIRMED`
+   - `STABLECOIN_PAYOUT_REFUND_FAILED`
 
 ## Passo a passo
 
@@ -200,6 +202,8 @@ curl --request POST \
 ### 6. Acompanhar a conclusão
 
 Quando o Pix é pago, você recebe `STABLECOIN_PAYOUT_COMPLETED` (pode incluir `endToEndId`). Em falha, `STABLECOIN_PAYOUT_FAILED`. Detalhes em [Webhooks](./stablecoin-webhooks.md).
+
+Um payout já liquidado ainda pode ser **devolvido** depois — o `status` continua `COMPLETED` e a devolução chega em `STABLECOIN_PAYOUT_REFUND_CONFIRMED` (valor disponível de novo) ou `STABLECOIN_PAYOUT_REFUND_FAILED` (valor indisponível, precisa de conciliação). Veja [Devolução de um payout já liquidado](./stablecoin-webhooks.md#devolução-de-um-payout-já-liquidado).
 
 Você também pode consultar a qualquer momento:
 

--- a/docs/stablecoin/stablecoin-webhooks.md
+++ b/docs/stablecoin/stablecoin-webhooks.md
@@ -75,7 +75,9 @@ Quando você cria um payout via `POST /api/v1/stablecoin/payout`, o resultado fi
 | Evento | Quando ocorre |
 | --- | --- |
 | `STABLECOIN_PAYOUT_COMPLETED` | O Pix foi pago / ticket do provedor em estado terminal de sucesso |
-| `STABLECOIN_PAYOUT_FAILED` | O payout falhou |
+| `STABLECOIN_PAYOUT_FAILED` | O payout falhou — o Pix **não** saiu |
+| `STABLECOIN_PAYOUT_REFUND_CONFIRMED` | O Pix saiu, voltou, e o valor está **disponível de novo** no seu saldo de stablecoin |
+| `STABLECOIN_PAYOUT_REFUND_FAILED` | O Pix saiu, voltou, mas o valor **não** está disponível para você |
 
 O objeto enviado contém `stablePayout` e `company`. O campo `correlationID` corresponde ao `correlationId` enviado na criação.
 
@@ -122,6 +124,96 @@ O objeto enviado contém `stablePayout` e `company`. O campo `correlationID` cor
   },
   "reason": "Payout failed",
   "errorCode": "PAYOUT-FAILED"
+}
+```
+
+### Devolução de um payout já liquidado
+
+Um payout liquidado pode voltar — o recebedor devolve o Pix, ou o banco dele rejeita o crédito. Nesse caso o `status` do payout **continua `COMPLETED`**: o Pix realmente saiu, e reverter o status quebraria a máquina de estados que você já construiu em cima do `STABLECOIN_PAYOUT_COMPLETED`. A devolução chega como um evento novo, com um bloco `refund`.
+
+`FAILED` e `REFUND_*` são mutuamente exclusivos no mesmo payout: `FAILED` significa que o Pix nunca saiu; `REFUND_*` significa que saiu e voltou.
+
+Campos do bloco `refund`:
+
+| Campo | Descrição |
+| --- | --- |
+| `status` | `CONFIRMED` ou `FAILED` — se o valor devolvido está disponível para você |
+| `amount` | Em centavos de `currency`, a mesma unidade do `stablePayout.inputAmount` — **nunca** o `outputAmount` em BRL |
+| `currency` | O ativo de entrada do payout, ex.: `BRLA`, `USDT` |
+| `destination` | `SUBACCOUNT_BALANCE` (sacável por você), `MAIN_BALANCE` (creditado fora da sua subconta, precisa de intervenção manual) ou `NONE` (nada foi creditado) |
+| `providerTicketId` | O ticket **da devolução**, não o do payout original. Use como chave de idempotência: uma reentrega repete o mesmo valor |
+| `originalProviderTicketId` | O ticket do payout original, quando o provedor informa |
+| `reason` | Motivo informado pelo provedor |
+| `refundEndToEndId` | O `endToEndId` da devolução Pix, quando existe |
+| `failureReason` | Só em `REFUND_FAILED`: por que o valor não está disponível |
+| `refundedAt` | Quando a devolução foi registrada |
+
+### STABLECOIN_PAYOUT_REFUND_CONFIRMED
+
+O valor voltou e está disponível de novo no seu saldo de stablecoin — é seguro reembolsar o seu cliente final.
+
+```json
+{
+  "event": "STABLECOIN_PAYOUT_REFUND_CONFIRMED",
+  "stablePayout": {
+    "id": "6a721b1e3c785acfaebfa01c",
+    "status": "COMPLETED",
+    "inputAmount": 3379,
+    "inputCurrency": "BRLA",
+    "outputAmount": 33.73,
+    "outputCurrency": "BRL",
+    "pixKey": "thiago@entria.com.br",
+    "endToEndId": "E123...",
+    "correlationID": "payout-001"
+  },
+  "company": {
+    "name": "Acme Corp"
+  },
+  "refund": {
+    "status": "CONFIRMED",
+    "amount": 3379,
+    "currency": "BRLA",
+    "destination": "SUBACCOUNT_BALANCE",
+    "providerTicketId": "9a1c4f7e-2b83-4d55-9c0e-1f6a2d3b4c5d",
+    "originalProviderTicketId": "018f2b2c-9a4d-4a6f-b0d5-7c9f1e2a3b44",
+    "reason": "payout reversed - original ticket id: 018f2b2c-9a4d-4a6f-b0d5-7c9f1e2a3b44",
+    "refundEndToEndId": "E54811417202608251402",
+    "refundedAt": "2026-08-25T14:02:41.318Z"
+  }
+}
+```
+
+### STABLECOIN_PAYOUT_REFUND_FAILED
+
+O valor voltou, mas **não** está disponível para você: ou a própria devolução não se concretizou, ou o crédito caiu fora da sua subconta. **Não credite o seu cliente final** — o caso precisa de conciliação.
+
+```json
+{
+  "event": "STABLECOIN_PAYOUT_REFUND_FAILED",
+  "stablePayout": {
+    "id": "6a721b1e3c785acfaebfa01c",
+    "status": "COMPLETED",
+    "inputAmount": 3379,
+    "inputCurrency": "BRLA",
+    "outputAmount": 33.73,
+    "outputCurrency": "BRL",
+    "pixKey": "thiago@entria.com.br",
+    "endToEndId": "E123...",
+    "correlationID": "payout-001"
+  },
+  "company": {
+    "name": "Acme Corp"
+  },
+  "refund": {
+    "status": "FAILED",
+    "amount": 3379,
+    "currency": "BRLA",
+    "destination": "NONE",
+    "providerTicketId": "9a1c4f7e-2b83-4d55-9c0e-1f6a2d3b4c5d",
+    "originalProviderTicketId": "018f2b2c-9a4d-4a6f-b0d5-7c9f1e2a3b44",
+    "failureReason": "returned funds not available in the sub-account balance",
+    "refundedAt": "2026-08-25T14:02:41.318Z"
+  }
 }
 ```
 


### PR DESCRIPTION
Depends on entria/woovi#102732 (event names) and entria/woovi-openapi#78 (API reference) — emitted by entria/woovi-stablecoin#341, part of entria/woovi-issues#4763.

Um payout de stablecoin já liquidado pode voltar: o recebedor devolve o Pix, ou o banco dele rejeita o crédito. O `status` do payout **continua `COMPLETED`** — o Pix realmente saiu, e reverter o status quebraria a máquina de estados que o integrador construiu em cima do `STABLECOIN_PAYOUT_COMPLETED`. Quem lê só o status nunca fica sabendo que o dinheiro voltou; a devolução chega como um evento novo, com um bloco `refund`.

| Evento | Quando ocorre |
|---|---|
| `STABLECOIN_PAYOUT_REFUND_CONFIRMED` | Voltou e o valor está **disponível de novo** no saldo de stablecoin — seguro reembolsar o cliente final |
| `STABLECOIN_PAYOUT_REFUND_FAILED` | Voltou mas o valor **não** está disponível — não credite o cliente final, precisa de conciliação |

- `docs/stablecoin/stablecoin-webhooks.md` — a tabela de eventos, a seção "Devolução de um payout já liquidado" com a tabela de campos do `refund`, e os dois payloads de exemplo
- `docs/stablecoin/stablecoin-payout-flow.md` — os dois eventos nos pré-requisitos de webhook e no passo "Acompanhar a conclusão"

Os pontos que o integrador erra se não estiverem escritos: `refund.amount` vem em **centavos do ativo de entrada** (mesma unidade do `stablePayout.inputAmount`, nunca o `outputAmount` em BRL); `refund.providerTicketId` é o ticket **da devolução**, não o do payout, e serve de chave de idempotência numa reentrega; e `FAILED` x `REFUND_*` são mutuamente exclusivos — `FAILED` é o Pix que nunca saiu.

Os `swaggers/woovi.json` e o postman não mudam: eles ainda não carregam nenhum webhook de stablecoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)