### PR TITLE
fix(docs): follow the routes that moved in the spec

### DIFF
--- a/docs/arquivos/upload-de-arquivo.md
+++ b/docs/arquivos/upload-de-arquivo.md
@@ -81,7 +81,7 @@ O corpo do erro traz a mensagem no idioma da empresa que fez a requisição (pt-
 
 ## Usando o arquivo em outra API
 
-Pegue o `file.id` do retorno e envie no campo correspondente da API que vai consumir o documento. Para disputas, ele vai no `fileId` de cada item de `documents` em `POST /api/v1/dispute/:id/evidence` — veja [Como adicionar uma nova evidência em uma disputa?](../disputa/how-add-new-evidence-in-evidence.md).
+Pegue o `file.id` do retorno e envie no campo correspondente da API que vai consumir o documento. Para disputas, ele vai no `fileId` de cada item de `documents` em `POST /api/v1/dispute/{id}/evidence` — veja [Como adicionar uma nova evidência em uma disputa?](../disputa/how-add-new-evidence-in-evidence.md).
 
 ## Casos de Uso
 

--- a/docs/customer/how-to-update-customer-data.md
+++ b/docs/customer/how-to-update-customer-data.md
@@ -32,7 +32,7 @@ Ao editar o campo não esqueça de clicar em salvar em cada campo.
 
 ## Via API
 
-Para alterar os dados de um cliente via API, você utiliza o _endpoint_ `/api/v1/customer/{correlationID}` da API utilizando o método `PATCH`.
+Para alterar os dados de um cliente via API, você utiliza o _endpoint_ `/api/v1/customer/{id}` da API utilizando o método `PATCH`.
 
 Para editar o cliente você precisa chamar a API informando o correlationID do cliente em que deseja alterar na URL, e no corpo da requisição você pode informar os campos `name`, `email`, `phone`, `address` and `taxID`.
 
@@ -110,4 +110,4 @@ Retornarmeros a seguinte resposta de exemplo:
 }
 ```
 
-Consulte a documentação da API para mais informações sobre os campos e a resposta da requisição aqui: [API](/api#tag/customer/PATCH/api/v1/customer/{correlationID})
+Consulte a documentação da API para mais informações sobre os campos e a resposta da requisição aqui: [API](/api#tag/customer/PATCH/api/v1/customer/{id})

--- a/docs/sdk/node/resources.md
+++ b/docs/sdk/node/resources.md
@@ -32,7 +32,7 @@ const response = await woovi.account.get({ accountId: 'algum-id' });
 
 Obtenha as contas usando o método `list` no recurso de contas:
 
-[Documentação do endpoint para mais detalhes](/api#tag/account/GET/api/v1/account/).
+[Documentação do endpoint para mais detalhes](/api#tag/account/GET/api/v1/account).
 
 ```js
 const response = await woovi.account.list({ limit: 10, skip: 0 }); //o objeto de paginação é opcional


### PR DESCRIPTION
entria/woovi#102733 corrected five paths in the public spec that described a route the API does not serve. It is live now — `api.woovi.com/api/openapi.json` serves 99 paths, no path containing `:`, none with a trailing slash — so the links here have to follow.

| | from | to |
| --- | --- | --- |
| link | `#tag/account/GET/api/v1/account/` | without the trailing slash |
| link | `#tag/customer/PATCH/api/v1/customer/{correlationID}` | `{id}` |
| prose | `` `/api/v1/customer/{correlationID}` `` | `{id}` |
| prose | `` `POST /api/v1/dispute/:id/evidence` `` | `{id}` |

The router serves one `:id` for both `GET` and `PATCH` on customer, so the spec used to show one route as two. `:id` is the Koa spelling — not a path anyone should send — and it was in the docs as prose, teaching it.

## Why this waits for the release rather than leading it

The remark plugin from #765 recomputes the **tag** in a reference link, not the **path**. A moved path is the one thing it cannot heal — and it fails the build when a link names an operation the served spec does not have. So opening this before the release would have broken the docs build; opening it after is the only order that works.

Worth stating plainly since I built that plugin: it protects against tag renames, which are presentation and change often. It does not protect against a path change, which is a contract change and should be rare. Both showed up today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RubjdcR9rED29TtG3rLEJ