### PR TITLE
docs(security): public remediation page for leaked credentials

### DIFF
--- a/docs/security/security-leaked-credentials.md
+++ b/docs/security/security-leaked-credentials.md
@@ -1,0 +1,147 @@
+---
+id: security-leaked-credentials
+title: "Credencial exposta ou vazada: como remediar"
+sidebar_label: Credencial vazada
+tags:
+  - security
+  - api
+  - leaked-credentials
+  - remediation
+---
+
+Esta é a documentação pública de remediação da Woovi para credenciais expostas.
+Use esta página se um AppID, `clientSecret` ou secret key de webhook da Woovi foi
+publicado em um repositório público, log, ticket, print, pacote npm/composer,
+bundle de frontend, ou detectado por uma ferramenta de _secret scanning_.
+
+:::danger Trate como comprometida
+Qualquer credencial que saiu do seu ambiente controlado deve ser considerada
+comprometida, mesmo que o repositório fosse privado, mesmo que o commit tenha
+sido revertido e mesmo que o vazamento tenha durado poucos minutos. Reescrever o
+histórico do Git **não** remedia o vazamento — só a rotação da credencial remedia.
+:::
+
+## Resumo (faça agora)
+
+1. **Rotacione ou revogue** a credencial no painel da Woovi — isso invalida a credencial exposta imediatamente.
+2. **Atualize seus sistemas** com a nova credencial.
+3. **Revise o extrato, as transações e a auditoria** do período em que a credencial ficou exposta e, se encontrar qualquer atividade que não reconhece, escreva para [security@woovi.com](mailto:security@woovi.com).
+
+## 1. Identifique o tipo de credencial
+
+| Credencial | Onde é usada | Como reconhecer | Risco |
+| - | - | - | - |
+| **AppID de API** | Header `Authorization` das chamadas a `api.woovi.com` | String base64 que decodifica para `Client_Id_<uuid>:Client_Secret_<...>` | **Alto** — permite chamar a API em nome da sua empresa, dentro dos escopos atribuídos |
+| **AppID de Plugin** | Frontend / checkout | Mesmo formato do AppID de API | **Baixo/Médio** — é público por design e só acessa rotas de plugin, mas recomendamos rotacionar |
+| **`clientSecret` de WooviApp** (OAuth) | Backend do seu app, na troca do `code` | Retornado uma única vez na criação do app em [store.woovi.com](https://store.woovi.com/create) | **Alto** — permite se passar pelo seu app no fluxo OAuth |
+| **`clientId` / `clientSecret` de Limites de Conta** | HTTP Basic Auth (`Authorization: Basic ...`) | Par de credenciais criado no painel de limites | **Alto** |
+| **Secret key HMAC de Webhook** | Validação do header `X-OpenPix-Signature` | Secret exibido no detalhe do webhook em `API/Plugins` | **Médio** — permite forjar webhooks que o seu sistema aceitaria como legítimos |
+
+Se você não conseguir identificar o tipo, trate como AppID de API (o cenário mais
+sensível) e siga o passo 2.
+
+## 2. Rotacione ou revogue a credencial
+
+### AppID de API ou de Plugin
+
+Rotacionar gera um novo AppID e **invalida o antigo imediatamente**:
+
+1. Acesse [app.woovi.com](https://app.woovi.com.br/home/applications/tab/list) e vá em **API/Plugins → API/Plugins**.
+2. Selecione a aplicação cuja chave foi exposta.
+3. Clique em **Regerar AppID**.
+4. Confirme com o seu segundo fator de autenticação (2FA).
+5. Copie o novo AppID — ele é exibido apenas nesse momento.
+
+Se a integração não é mais usada, prefira **remover a aplicação** em vez de
+rotacionar. Você também pode remover a aplicação pela API, autenticando com o
+próprio AppID exposto:
+
+```bash
+curl --request DELETE \
+  --url https://api.woovi.com/api/v1/application \
+  --header 'Authorization: APPID_EXPOSTO'
+```
+
+Essa rota exige o escopo `APPLICATION_DELETE`. A aplicação _master_ da empresa
+não pode ser removida — nesse caso, rotacione pelo painel.
+
+:::tip
+Se a mesma credencial estava em uso por várias integrações, crie um AppID por
+integração antes de rotacionar. Assim o próximo incidente afeta apenas um sistema.
+:::
+
+### `clientSecret` de WooviApp (OAuth)
+
+O `clientSecret` é exibido apenas uma vez na criação e a Woovi armazena somente o
+hash SHA-256 dele — não há como recuperá-lo nem rotacioná-lo. Para remediar:
+
+1. Cadastre um novo app em [store.woovi.com/create](https://store.woovi.com/create) com as mesmas _redirect URIs_ e permissões.
+2. Migre seu backend para o novo `clientId` / `clientSecret`.
+3. Remova o app antigo.
+
+Cada empresa que autorizou o seu app pode revogar o acesso a qualquer momento em
+[store.woovi.com/authorized-apps](https://store.woovi.com/authorized-apps), e a
+revogação invalida o _access token_ imediatamente. Oriente seus clientes a
+revogar o app antigo depois da migração.
+
+### `clientId` / `clientSecret` de Limites de Conta
+
+Crie um novo par de credenciais no painel, atualize sua integração e remova o par
+exposto.
+
+### Secret key HMAC de Webhook
+
+A secret key faz parte da configuração do webhook. Para trocá-la, remova o
+webhook e cadastre-o novamente — o novo webhook recebe uma nova secret key.
+Consulte [Validando Webhook payload usando HMAC-SHA1](../webhook/seguranca/webhook-hmac.mdx).
+
+Considere migrar para a validação por
+[chave pública (`x-webhook-signature`)](../webhook/seguranca/webhook-signature-validation.mdx),
+que não depende de um secret compartilhado e portanto não pode vazar do seu lado.
+
+## 3. Avalie o impacto
+
+Com a credencial rotacionada, verifique o que aconteceu enquanto ela estava exposta:
+
+- **Extrato e transações** — procure cobranças, pagamentos, saques ou reembolsos que você não reconhece.
+- **Auditoria** — todas as ações na plataforma são auditadas com IP e geolocalização.
+- **Sessões** — confira as sessões ativas e os alertas de login de dispositivos ou locais desconhecidos.
+- **Webhooks** — se a secret key HMAC vazou, revise os eventos que seu sistema processou no período.
+
+Encontrou algo suspeito? Escreva imediatamente para
+[security@woovi.com](mailto:security@woovi.com) com o AppID afetado (nunca o
+valor completo da credencial), a janela de tempo e o que você observou.
+
+## 4. Previna o próximo vazamento
+
+- **Nunca versione credenciais.** Use variáveis de ambiente ou um gerenciador de segredos.
+- **Restrinja escopos.** Um AppID sem escopos definidos tem acesso completo às rotas do seu tipo de aplicação. Veja [Adicionando escopos ao seu AppID](../apis/api-scopes.md).
+- **Restrinja IPs.** Libere apenas os IPs dos seus servidores. Veja [Adicionando filtro de IP à sua API](../apis/api-security-ip-whitelist.md).
+- **Uma chave por integração.** Não reutilize AppIDs entre serviços ou ambientes.
+- **Desative chaves não utilizadas.**
+- **Nunca use um AppID de API no frontend.** Para frontend existe o tipo Plugin.
+- **Habilite MFA** para todos os usuários da sua empresa. Veja [Autenticação multi-fator](./security-user-mfa.md).
+- **Ative o _secret scanning_** no seu provedor de Git para ser avisado antes de nós.
+
+## 5. Fale com a Woovi
+
+| Assunto | Canal |
+| - | - |
+| Credencial vazada, atividade suspeita, incidente de segurança | [security@woovi.com](mailto:security@woovi.com) · [infosec@woovi.com](mailto:infosec@woovi.com) |
+| Divulgação responsável de vulnerabilidade | [security@woovi.com](mailto:security@woovi.com) |
+| Dúvidas de integração e suporte | [ajuda.woovi.com](https://ajuda.woovi.com) |
+
+## Para plataformas de _secret scanning_
+
+Esta página é a URL canônica de remediação pública da Woovi e pode ser
+referenciada em alertas de vazamento de credenciais Woovi.
+
+- Português: `https://developers.woovi.com/docs/security/security-leaked-credentials`
+- English: `https://developers.woovi.com/en/docs/security/security-leaked-credentials`
+
+Para reportar credenciais Woovi encontradas em fontes públicas, ou para tratar de
+um programa de parceria de _secret scanning_, escreva para
+[security@woovi.com](mailto:security@woovi.com).
+
+Veja também: [Política de Segurança](./security-policy.md) e
+[Diretrizes de Segurança](./security-guidelines.md).

--- a/i18n/en/docusaurus-plugin-content-docs/current/security/security-leaked-credentials.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/security/security-leaked-credentials.md
@@ -1,0 +1,147 @@
+---
+id: security-leaked-credentials
+title: "Leaked or exposed credential: how to remediate"
+sidebar_label: Leaked credential
+tags:
+  - security
+  - api
+  - leaked-credentials
+  - remediation
+---
+
+This is Woovi's public remediation documentation for exposed credentials. Use
+this page if a Woovi AppID, `clientSecret` or webhook secret key was published in
+a public repository, log, ticket, screenshot, npm/composer package, frontend
+bundle, or was flagged by a secret scanning tool.
+
+:::danger Treat it as compromised
+Any credential that left your controlled environment must be considered
+compromised — even if the repository was private, even if the commit was
+reverted, and even if the exposure lasted only a few minutes. Rewriting Git
+history does **not** remediate a leak; only rotating the credential does.
+:::
+
+## TL;DR (do this now)
+
+1. **Rotate or revoke** the credential in the Woovi dashboard — this invalidates the exposed credential immediately.
+2. **Update your systems** with the new credential.
+3. **Review your statement, transactions and audit trail** for the exposure window, and email [security@woovi.com](mailto:security@woovi.com) if you see any activity you do not recognize.
+
+## 1. Identify the credential type
+
+| Credential | Where it is used | How to recognize it | Risk |
+| - | - | - | - |
+| **API AppID** | `Authorization` header on calls to `api.woovi.com` | Base64 string that decodes to `Client_Id_<uuid>:Client_Secret_<...>` | **High** — can call the API on behalf of your company, within its assigned scopes |
+| **Plugin AppID** | Frontend / checkout | Same format as the API AppID | **Low/Medium** — public by design and limited to plugin routes, but rotation is still recommended |
+| **WooviApp `clientSecret`** (OAuth) | Your app's backend, when exchanging the `code` | Returned only once when the app is created at [store.woovi.com](https://store.woovi.com/create) | **High** — allows impersonating your app in the OAuth flow |
+| **Account Limits `clientId` / `clientSecret`** | HTTP Basic Auth (`Authorization: Basic ...`) | Credential pair created in the limits dashboard | **High** |
+| **Webhook HMAC secret key** | Validating the `X-OpenPix-Signature` header | Secret shown on the webhook detail screen under `API/Plugins` | **Medium** — allows forging webhooks your system would accept as legitimate |
+
+If you cannot tell which type it is, treat it as an API AppID (the most sensitive
+case) and follow step 2.
+
+## 2. Rotate or revoke the credential
+
+### API or Plugin AppID
+
+Rotating issues a new AppID and **invalidates the old one immediately**:
+
+1. Go to [app.woovi.com](https://app.woovi.com.br/home/applications/tab/list) and open **API/Plugins → API/Plugins**.
+2. Select the application whose key was exposed.
+3. Click **Regenerate AppID**.
+4. Confirm with your second authentication factor (2FA).
+5. Copy the new AppID — it is shown only at that moment.
+
+If the integration is no longer in use, **delete the application** instead of
+rotating it. You can also delete it through the API, authenticating with the
+exposed AppID itself:
+
+```bash
+curl --request DELETE \
+  --url https://api.woovi.com/api/v1/application \
+  --header 'Authorization: EXPOSED_APPID'
+```
+
+This route requires the `APPLICATION_DELETE` scope. Your company's _master_
+application cannot be deleted — rotate it from the dashboard instead.
+
+:::tip
+If the same credential was shared by several integrations, create one AppID per
+integration before rotating. That way the next incident affects only one system.
+:::
+
+### WooviApp `clientSecret` (OAuth)
+
+The `clientSecret` is shown only once at creation time and Woovi stores only its
+SHA-256 hash — it cannot be recovered or rotated. To remediate:
+
+1. Register a new app at [store.woovi.com/create](https://store.woovi.com/create) with the same redirect URIs and permissions.
+2. Migrate your backend to the new `clientId` / `clientSecret`.
+3. Delete the old app.
+
+Every company that authorized your app can revoke access at any time at
+[store.woovi.com/authorized-apps](https://store.woovi.com/authorized-apps), and
+revoking invalidates the access token immediately. Ask your customers to revoke
+the old app after the migration.
+
+### Account Limits `clientId` / `clientSecret`
+
+Create a new credential pair in the dashboard, update your integration and delete
+the exposed pair.
+
+### Webhook HMAC secret key
+
+The secret key is part of the webhook configuration. To change it, delete the
+webhook and create it again — the new webhook gets a new secret key. See
+[Validating the webhook payload with HMAC-SHA1](../webhook/seguranca/webhook-hmac.mdx).
+
+Consider migrating to
+[public key validation (`x-webhook-signature`)](../webhook/seguranca/webhook-signature-validation.mdx),
+which does not rely on a shared secret and therefore cannot leak from your side.
+
+## 3. Assess the impact
+
+Once the credential is rotated, check what happened while it was exposed:
+
+- **Statement and transactions** — look for charges, payments, withdrawals or refunds you do not recognize.
+- **Audit trail** — every action on the platform is audited with IP and geolocation.
+- **Sessions** — review active sessions and alerts for logins from unknown devices or locations.
+- **Webhooks** — if the HMAC secret key leaked, review the events your system processed during the window.
+
+Found something suspicious? Email [security@woovi.com](mailto:security@woovi.com)
+right away with the affected AppID (never the full credential value), the time
+window and what you observed.
+
+## 4. Prevent the next leak
+
+- **Never commit credentials.** Use environment variables or a secret manager.
+- **Restrict scopes.** An AppID with no scopes has full access to every route allowed for its application type. See [Adding scopes to your AppID](../apis/api-scopes.md).
+- **Restrict IPs.** Allow only your servers' IPs. See [Adding an IP filter to your API](../apis/api-security-ip-whitelist.md).
+- **One key per integration.** Do not reuse AppIDs across services or environments.
+- **Disable unused keys.**
+- **Never use an API AppID in the frontend.** Use the Plugin type for frontend integrations.
+- **Enable MFA** for every user in your company. See [Multi-factor authentication](./security-user-mfa.md).
+- **Turn on secret scanning** in your Git provider so you hear about a leak before we do.
+
+## 5. Contact Woovi
+
+| Topic | Channel |
+| - | - |
+| Leaked credential, suspicious activity, security incident | [security@woovi.com](mailto:security@woovi.com) · [infosec@woovi.com](mailto:infosec@woovi.com) |
+| Responsible vulnerability disclosure | [security@woovi.com](mailto:security@woovi.com) |
+| Integration questions and support | [ajuda.woovi.com](https://ajuda.woovi.com) |
+
+## For secret scanning platforms
+
+This page is Woovi's canonical public remediation URL and may be referenced in
+alerts about leaked Woovi credentials.
+
+- English: `https://developers.woovi.com/en/docs/security/security-leaked-credentials`
+- Portuguese: `https://developers.woovi.com/docs/security/security-leaked-credentials`
+
+To report Woovi credentials found in public sources, or to discuss a secret
+scanning partner program, email
+[security@woovi.com](mailto:security@woovi.com).
+
+See also: [Security Policy](./security-policy.md) and
+[Security Guidelines](./security-guidelines.md).


### PR DESCRIPTION
## Why

Secret scanning partner programs (GitHub, GitGuardian, TruffleHog, etc.) ask for a **Public Remediation Documentation** URL — a public page that tells a developer what to do when a credential of ours leaks. We didn't have one.

This adds that page, in pt-BR and en.

## URLs

- `https://developers.woovi.com/docs/security/security-leaked-credentials`
- `https://developers.woovi.com/en/docs/security/security-leaked-credentials`

## What the page covers

1. **Identify the credential type** — API AppID, Plugin AppID, WooviApp `clientSecret`, Account Limits `clientId`/`clientSecret`, webhook HMAC secret key — with how to recognize each and its risk level.
2. **Rotate or revoke** — the `API/Plugins → Regerar AppID` flow, `DELETE /api/v1/application` for unused apps, the "create a new app" path for WooviApp secrets (secret is only shown once, only the SHA-256 hash is stored), and recreating a webhook to change its HMAC secret.
3. **Assess impact** — statement/transactions, audit trail, sessions, webhook events for the exposure window.
4. **Prevent recurrence** — scopes, IP allowlist, one key per integration, never an API AppID in the frontend, MFA, secret scanning.
5. **Contact** — `security@woovi.com` / `infosec@woovi.com`.
6. **A section addressed to secret scanning platforms**, declaring this the canonical remediation URL.

## Also published

The same content is live on the help center, under Segurança: https://ajuda.woovi.com/hc/duvidas-frequentes/articles/1787748307-credencial-exposta-ou-vazada-como-remediar-app_id-client_secret-webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)