### PR TITLE
docs(partnerships): fix broken API reference links and add a curl example

### DIFF
--- a/docs/partnerships/how-to-create-a-affiliate-company-via-api.md
+++ b/docs/partnerships/how-to-create-a-affiliate-company-via-api.md
@@ -10,10 +10,10 @@ tags:
 
 ## Criando uma empresa afiliada
 
-Nós disponibilizamos o _endpoint_ `/api/woovi/v1/partner/application` para que
-você possa criar uma novo _pré-registro_ para a uma empresa afiliada.
+Nós disponibilizamos o _endpoint_ `POST /api/v1/partner/company` para que
+você possa criar um novo _pré-registro_ para uma empresa afiliada.
 
-Você pode acessar [aqui](/api#tag/partner-request-access)/paths/~1api~1v1~1partner~1company/post)
+Você pode acessar [aqui](/api#tag/partner-request-access/POST/api/v1/partner/company)
 a documentação referente a esse _endpoint_.
 
 Como parte do `body` da requisição, esperamos o envio dos seguintes dois objetos: `preRegistration` e `user`,
@@ -23,6 +23,34 @@ respectivamente, eles consistem no seguinte:
 - **`user`**: Os dados do usuário de acesso mestre aquela empresa, toda empresa afiliada precisa de um usuário mestre para que seja possível efetuar o login na plataforma posteriormente
 
 Em um exemplo prático, o body da sua requisição seguiria semelhante a este exemplo:
+
+```bash
+curl -X POST "https://api.woovi.com/api/v1/partner/company" \
+  -H "Authorization: {APP_ID}" \
+  -H "Content-Type: application/json" \
+  --data-raw '{
+    "preRegistration": {
+      "name": "Example LLC",
+      "taxID": {
+        "taxID": "11111111111111",
+        "type": "BR:CNPJ"
+      },
+      "website": "examplellc.com"
+    },
+    "user": {
+      "firstName": "John",
+      "lastName": "Doe",
+      "email": "johndoe@examplellc.com",
+      "phone": "+5511912345678",
+      "taxID": {
+        "taxID": "1111111111",
+        "type": "BR:CPF"
+      }
+    }
+  }'
+```
+
+O mesmo `body`, isolado:
 
 ```json
 {
@@ -50,7 +78,7 @@ Em um exemplo prático, o body da sua requisição seguiria semelhante a este ex
 Após efetuar a requisição, se tudo ocorreu bem, o _status code_ da requisição será `2xx` e no `body` da resposta,
 você estará vendo as informações sobre o seu afiliado recém criado.
 
-Em um exemplo, essa será a resposta a nossa resposta:
+Em um exemplo, essa será a nossa resposta:
 
 ```json
 {

--- a/docs/partnerships/how-to-integrate-as-woovi-partner.md
+++ b/docs/partnerships/how-to-integrate-as-woovi-partner.md
@@ -97,7 +97,7 @@ Você pode criar chaves de APIs para suas empresas afiliadas, seguindo a documen
 ## Como listar todos afiliados via API
 
 Você pode fazer um chamada para o nosso endpoint `/api/v1/partner/company` informando o seu `appID` utilizando os header de `Authorization`
-Para saber mais sobre as especificações do nosso endpoint você pode acessar [nossa documentação tecnica](/api#tag/partner-request-access)/paths/~1api~1v1~1partner~1company/get)
+Para saber mais sobre as especificações do nosso endpoint você pode acessar [nossa documentação tecnica](/api#tag/partner-request-access/GET/api/v1/partner/company)
 
 ![](./__assets__/how-to-integrate-as-woovi-partner/postman-get-affilliates.png)
 
@@ -109,7 +109,7 @@ Caso ainda não tenha um `appID`, recomenda-mos fortemente você consultar nossa
 ## Como listar um afiliado específico?
 
 Você pode fazer um chamada para o nosso endpoint `/api/v1/partner/company/{taxID}` informando o seu `appID` no header de `Authorization` da sua requisição, e também substituindo o parâmetro `taxID` pelo CNPJ do seu afiliado pré-registrado
-Para saber mais sobre as especificações do nosso endpoint você pode acessar [nossa documentação tecnica](/api#tag/partner-request-access)/paths/~1api~1v1~1partner~1company~1%7BtaxID%7D/get)
+Para saber mais sobre as especificações do nosso endpoint você pode acessar [nossa documentação tecnica](/api#tag/partner-request-access/GET/api/v1/partner/company/{taxID})
 
 ![](./__assets__/how-to-integrate-as-woovi-partner/postman-get-affiliate-by-taxID.png)
 

--- a/docs/payment/payment-how-to-auto-approve.md
+++ b/docs/payment/payment-how-to-auto-approve.md
@@ -103,4 +103,4 @@ Ao tentar aprovar com saldo insuficiente, a requisição retornará erro `400`:
 
 ## Referência da API
 
-Acesse a documentação completa do endpoint em [API Reference](/api#tag/payment-request-access)/paths/~1api~1v1~1payment/post).
+Acesse a documentação completa do endpoint em [API Reference](/api#tag/payment-request-access/POST/api/v1/payment).

--- a/docs/sdk/node/resources.md
+++ b/docs/sdk/node/resources.md
@@ -290,7 +290,7 @@ const response = await woovi.partner.getPreRegistration({
 
 Obtenha os pré-registros de parceiros usando o método `list` no recurso de parceiros:
 
-[Documentação do endpoint para mais detalhes](</api#tag/partner-request-access)/paths/~1api~1v1~1partner~1company/get>).
+[Documentação do endpoint para mais detalhes](</api#tag/partner-request-access/GET/api/v1/partner/company>).
 
 ```js
 const response = await woovi.partner.list({ limit: 10, skip: 0 }); //o objeto de paginação é opcional
@@ -300,7 +300,7 @@ const response = await woovi.partner.list({ limit: 10, skip: 0 }); //o objeto de
 
 Crie uma parceiro usando o método `create` no recurso de parceiros:
 
-[Documentação do endpoint para mais detalhes](</api#tag/partner-request-access)/paths/~1api~1v1~1partner~1company/post>).
+[Documentação do endpoint para mais detalhes](</api#tag/partner-request-access/POST/api/v1/partner/company>).
 
 ```js
 const response = await woovi.partner.create({
@@ -325,7 +325,7 @@ const response = await woovi.partner.create({
 
 Para criar uma aplicação, use o método `createApplication` no recurso de parceiros.
 
-[Documentação do endpoint para mais detalhes](</api#tag/partner-request-access)/paths/~1api~1v1~1partner~1application/post>).
+[Documentação do endpoint para mais detalhes](</api#tag/partner-request-access/POST/api/v1/partner/application>).
 
 ```js
 const response = await woovi.partner.createApplication({
@@ -350,7 +350,7 @@ Chame o método `payment` seu cliente da API para obter o recurso de pagamentos.
 
 Chame o método `approve` no recurso de pagamentos passando um correlationID:
 
-[Documentação do endpoint para mais detalhes](</api#tag/payment-request-access)/paths/~1api~1v1~1payment~1approve/post>).
+[Documentação do endpoint para mais detalhes](</api#tag/payment-request-access/POST/api/v1/payment/approve>).
 
 ```js
 const response = await woovi.payment.approve({
@@ -362,7 +362,7 @@ const response = await woovi.payment.approve({
 
 Obtenha um pagamento usando o método `get` no recurso de pagamentos:
 
-[Documentação do endpoint para mais detalhes](</api#tag/payment-request-access)/paths/~1api~1v1~1payment~1%7Bid%7D/get>).
+[Documentação do endpoint para mais detalhes](</api#tag/payment-request-access/GET/api/v1/payment/{id}>).
 
 ```js
 const response = await woovi.payment.get({ id: 'algum-id' });
@@ -372,7 +372,7 @@ const response = await woovi.payment.get({ id: 'algum-id' });
 
 Obtenha uma lista de pagamentos usando o método `list` no recurso de pagamentos.
 
-[Documentação do endpoint para mais detalhes](</api#tag/payment-request-access)/paths/~1api~1v1~1payment/get>).
+[Documentação do endpoint para mais detalhes](</api#tag/payment-request-access/GET/api/v1/payment>).
 
 ```js
 const response = await woovi.payment.list({ limit: 10, skip: 0 }); //o objeto de paginação é opcional
@@ -382,7 +382,7 @@ const response = await woovi.payment.list({ limit: 10, skip: 0 }); //o objeto de
 
 Para criar uma requisição de pagamento, use o método `create` no recurso de payment.
 
-[Documentação do endpoint para mais detalhes](</api#tag/payment-request-access)/paths/~1api~1v1~1payment/post>).
+[Documentação do endpoint para mais detalhes](</api#tag/payment-request-access/POST/api/v1/payment>).
 
 ```js
 const response = await woovi.payment.create({


### PR DESCRIPTION
## Problema

Na página [Como criar uma empresa afiliada via API](https://developers.woovi.com/en/docs/partnerships/how-to-create-a-affiliate-company-via-api) o link "aqui" quebra e o resto do anchor vaza como texto literal:

> Você pode acessar aqui`/paths/1api1v11partner1company/post)` a documentação referente a esse _endpoint_.

A causa é um `)` sobrando no anchor antigo (pré-Scalar):

```
[aqui](/api#tag/partner-request-access)/paths/~1api~1v1~1partner~1company/post)
                                      ^ fecha o link aqui
```

Mesmo defeito em **11 links** espalhados por 4 arquivos (`partnerships`, `payment`, `sdk/node`).

## O que foi feito

1. **Todos os 11 links** reescritos para o formato `#tag/<tag>/<METHOD>/<path>` que o plugin `remarkApiRefLinks` entende — assim a tag é recomputada a partir do spec servido no build e não envelhece de novo em silêncio.
2. **Endpoint errado corrigido**: a página dizia `/api/woovi/v1/partner/application`. Esse prefixo `woovi` não existe no router (`openPixApiRouter.ts` só monta `/api/v1/...` e `/api/openpix/v1/...`), e `application` é outro recurso. O correto para o pré-registro é `POST /api/v1/partner/company`.
3. **Exemplo curl** adicionado, pronto para copiar e rodar.
4. Typo "essa será a resposta a nossa resposta" → "essa será a nossa resposta".

## Verificação

Os 118 links de API reference do repo foram validados contra o spec servido (`https://api.woovi.com/api/openapi.json`) — a mesma checagem que `remarkApiRefLinks` faz no build: **118 válidos, 0 ausentes**.

`pnpm build` não roda neste checkout por causa de `@designcodeio/threeui` (dep privada não instalada) — falha pré-existente e sem relação com markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)