### PR TITLE
docs(stablecoin): add dedicated API reference

### DIFF
--- a/docs/stablecoin/stablecoin-endpoints.md
+++ b/docs/stablecoin/stablecoin-endpoints.md
@@ -9,7 +9,7 @@ tags:
 
 ## Rotas da API de Stablecoin
 
-Você pode ver os detalhes completos na [referência da API](/api#tag/stablecoin).
+Você pode ver os detalhes completos na [referência da API Stablecoin](/stable).
 
 Todas as rotas ficam sob `/api/v1/stablecoin/` e exigem autenticação com o seu App (header `Authorization`). Cada rota exige um escopo (`scope`) específico no seu App:
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -252,6 +252,11 @@ module.exports = {
           position: 'left',
         },
         {
+          to: '/stable',
+          label: 'Stable',
+          position: 'left',
+        },
+        {
           to: 'docs/apis/api-explorer',
           label: 'API Explorer',
           position: 'left',

--- a/src/openapi/stableOpenApi.ts
+++ b/src/openapi/stableOpenApi.ts
@@ -1,0 +1,148 @@
+type OpenApiRecord = Record<string, unknown>;
+
+type StableSection = {
+  name: 'On Ramp' | 'Off Ramp' | 'Wallets';
+  description: string;
+};
+
+const STABLECOIN_PATH_PREFIX = '/api/v1/stablecoin';
+
+const STABLE_SCOPES = {
+  STABLECOIN_DEPOSIT_CREATE: 'Quote, create and approve stablecoin deposits',
+  STABLECOIN_PAYOUT_CREATE: 'Quote, create and inspect stablecoin payouts',
+  STABLECOIN_SUBACCOUNT_CREATE: 'Request a stablecoin subaccount and KYB',
+  STABLECOIN_SUBACCOUNT_LIST:
+    'Inspect stablecoin subaccounts, wallets and balances',
+};
+
+const STABLE_SECTIONS: StableSection[] = [
+  {
+    name: 'On Ramp',
+    description:
+      'Convert BRL received through Pix into stablecoins, from quote to on-chain settlement.',
+  },
+  {
+    name: 'Off Ramp',
+    description:
+      'Convert a stablecoin balance into BRL and pay it out to a Pix destination.',
+  },
+  {
+    name: 'Wallets',
+    description:
+      'Create and inspect stablecoin subaccounts, deposit addresses and available balances.',
+  },
+];
+
+const HTTP_METHODS = new Set([
+  'delete',
+  'get',
+  'head',
+  'options',
+  'patch',
+  'post',
+  'put',
+  'trace',
+]);
+
+const isRecord = (value: unknown): value is OpenApiRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const getStableSection = (path: string): StableSection => {
+  if (
+    path === `${STABLECOIN_PATH_PREFIX}/quote` ||
+    path.startsWith(`${STABLECOIN_PATH_PREFIX}/deposit`)
+  ) {
+    return STABLE_SECTIONS[0];
+  }
+
+  if (path.startsWith(`${STABLECOIN_PATH_PREFIX}/payout`)) {
+    return STABLE_SECTIONS[1];
+  }
+
+  return STABLE_SECTIONS[2];
+};
+
+const tagOperations = (path: string, pathItem: unknown): unknown => {
+  if (!isRecord(pathItem)) return pathItem;
+
+  const section = getStableSection(path);
+
+  return Object.fromEntries(
+    Object.entries(pathItem).map(([key, value]) => {
+      if (!HTTP_METHODS.has(key) || !isRecord(value)) return [key, value];
+
+      return [key, { ...value, tags: [section.name] }];
+    }),
+  );
+};
+
+const replaceWithStableScopes = (components: unknown): unknown => {
+  if (!isRecord(components) || !isRecord(components.securitySchemes)) {
+    return components;
+  }
+
+  const securitySchemes = Object.fromEntries(
+    Object.entries(components.securitySchemes).map(([name, scheme]) => {
+      if (!isRecord(scheme) || !isRecord(scheme.flows)) return [name, scheme];
+
+      const flows = Object.fromEntries(
+        Object.entries(scheme.flows).map(([flowName, flow]) => [
+          flowName,
+          isRecord(flow) ? { ...flow, scopes: STABLE_SCOPES } : flow,
+        ]),
+      );
+
+      return [name, { ...scheme, flows }];
+    }),
+  );
+
+  return { ...components, securitySchemes };
+};
+
+/**
+ * Creates the focused document rendered at /stable from the canonical Woovi
+ * OpenAPI document. Components are intentionally preserved so every $ref in a
+ * stablecoin operation keeps resolving, while unrelated paths and webhooks are
+ * removed from the reference.
+ */
+const buildStableOpenApi = (document: unknown): OpenApiRecord => {
+  if (!isRecord(document) || !isRecord(document.paths)) {
+    throw new Error('The Woovi OpenAPI document is invalid.');
+  }
+
+  const stablePaths = Object.entries(document.paths)
+    .filter(([path]) => path.startsWith(STABLECOIN_PATH_PREFIX))
+    .sort(([pathA], [pathB]) => {
+      const sectionA = STABLE_SECTIONS.indexOf(getStableSection(pathA));
+      const sectionB = STABLE_SECTIONS.indexOf(getStableSection(pathB));
+
+      return sectionA - sectionB;
+    })
+    .map(([path, pathItem]) => [path, tagOperations(path, pathItem)]);
+
+  if (stablePaths.length === 0) {
+    throw new Error(
+      'No stablecoin endpoints were found in the Woovi OpenAPI document.',
+    );
+  }
+
+  const stableDocument: OpenApiRecord = {
+    ...document,
+    info: {
+      ...(isRecord(document.info) ? document.info : {}),
+      title: 'Woovi Stablecoin API',
+      description:
+        'APIs for BRL on-ramp, Pix off-ramp and stablecoin wallet infrastructure.',
+    },
+    tags: STABLE_SECTIONS,
+    paths: Object.fromEntries(stablePaths),
+    components: replaceWithStableScopes(document.components),
+  };
+
+  delete stableDocument.webhooks;
+
+  return stableDocument;
+};
+
+export { buildStableOpenApi, STABLE_SECTIONS, STABLECOIN_PATH_PREFIX };
+export type { StableSection };

--- a/src/pages/stable.module.css
+++ b/src/pages/stable.module.css
@@ -1,0 +1,96 @@
+.reference {
+  height: calc(100vh - 60px);
+}
+
+.status {
+  align-items: center;
+  background:
+    radial-gradient(
+      circle at 12% 20%,
+      rgb(37 194 160 / 14%),
+      transparent 30rem
+    ),
+    #f8fbfa;
+  color: #17352d;
+  display: flex;
+  justify-content: center;
+  min-height: calc(100vh - 60px);
+  padding: 2rem;
+}
+
+.statusCard {
+  background: rgb(255 255 255 / 88%);
+  border: 1px solid rgb(23 53 45 / 12%);
+  border-radius: 0.75rem;
+  box-shadow: 0 1.5rem 4rem rgb(9 48 40 / 10%);
+  max-width: 30rem;
+  padding: 2rem;
+  text-align: center;
+  width: 100%;
+}
+
+.statusMark {
+  animation: breathe 1.4s ease-in-out infinite;
+  background: #25c2a0;
+  border-radius: 999px;
+  display: inline-block;
+  height: 0.75rem;
+  margin-bottom: 1rem;
+  width: 0.75rem;
+}
+
+.statusCard h1 {
+  font-size: 1.25rem;
+  margin: 0 0 0.5rem;
+}
+
+.statusCard p {
+  color: #557069;
+  margin: 0;
+}
+
+.statusCard a {
+  color: #087f67;
+  display: inline-block;
+  font-weight: 600;
+  margin-top: 1rem;
+}
+
+@keyframes breathe {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgb(37 194 160 / 25%);
+    opacity: 0.65;
+  }
+
+  50% {
+    box-shadow: 0 0 0 0.5rem rgb(37 194 160 / 0%);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .statusMark {
+    animation: none;
+  }
+}
+
+:global(html[data-theme='dark']) .status {
+  background:
+    radial-gradient(
+      circle at 12% 20%,
+      rgb(37 194 160 / 12%),
+      transparent 30rem
+    ),
+    #101714;
+  color: #eff8f5;
+}
+
+:global(html[data-theme='dark']) .statusCard {
+  background: rgb(22 34 29 / 92%);
+  border-color: rgb(210 239 231 / 12%);
+}
+
+:global(html[data-theme='dark']) .statusCard p {
+  color: #abc1bb;
+}

--- a/src/pages/stable.tsx
+++ b/src/pages/stable.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react';
+
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import Layout from '@theme/Layout';
+
+import { buildStableOpenApi } from '../openapi/stableOpenApi';
+
+import styles from './stable.module.css';
+
+const OPENAPI_URL = 'https://api.woovi.com/api/openapi.json';
+
+type ApiReferenceComponent =
+  (typeof import('@scalar/api-reference-react'))['ApiReferenceReact'];
+
+const LoadingState = () => (
+  <div className={styles.status}>
+    <div className={styles.statusCard} role='status'>
+      <span className={styles.statusMark} aria-hidden='true' />
+      <h1>Loading Stablecoin API</h1>
+      <p>Preparing On Ramp, Off Ramp and Wallets endpoints.</p>
+    </div>
+  </div>
+);
+
+function StableApiReference() {
+  const [ApiReference, setApiReference] =
+    useState<ApiReferenceComponent | null>(null);
+  const [openApi, setOpenApi] = useState<Record<string, unknown> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    let mounted = true;
+
+    const loadReference = async () => {
+      try {
+        const [scalar, response] = await Promise.all([
+          import('@scalar/api-reference-react'),
+          fetch(OPENAPI_URL, { signal: abortController.signal }),
+          import('@scalar/api-reference-react/style.css'),
+        ]);
+
+        if (!response.ok) {
+          throw new Error(
+            `OpenAPI request failed with status ${response.status}.`,
+          );
+        }
+
+        const stableOpenApi = buildStableOpenApi(await response.json());
+
+        if (mounted) {
+          setApiReference(() => scalar.ApiReferenceReact);
+          setOpenApi(stableOpenApi);
+        }
+      } catch (loadError) {
+        if (mounted && !abortController.signal.aborted) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : 'The Stablecoin API reference could not be loaded.',
+          );
+        }
+      }
+    };
+
+    void loadReference();
+
+    return () => {
+      mounted = false;
+      abortController.abort();
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div className={styles.status}>
+        <div className={styles.statusCard} role='alert'>
+          <h1>Stablecoin API is unavailable</h1>
+          <p>{error}</p>
+          <a href={OPENAPI_URL}>Open the complete OpenAPI document</a>
+        </div>
+      </div>
+    );
+  }
+
+  if (!ApiReference || !openApi) return <LoadingState />;
+
+  return (
+    <div className={styles.reference}>
+      <ApiReference
+        configuration={{
+          content: openApi,
+          hideModels: true,
+          theme: 'default',
+        }}
+      />
+    </div>
+  );
+}
+
+export default function StableApiPage() {
+  return (
+    <Layout
+      title='Stablecoin API'
+      description='Woovi Stablecoin API: On Ramp, Off Ramp and Wallets'
+    >
+      <BrowserOnly fallback={<LoadingState />}>
+        {() => <StableApiReference />}
+      </BrowserOnly>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary

- add a dedicated Stablecoin API reference at `/stable`
- group the canonical Stablecoin operations into On Ramp, Off Ramp and Wallets
- expose only Stablecoin authorization scopes and hide unrelated API models
- add the `Stable` navbar tab and update the existing Stablecoin documentation link

## Validation

- `pnpm build:ptbr`
- targeted ESLint for the new transformer/page (with the repository's unresolved Docusaurus alias rule disabled)
- OpenAPI transformation assertion: 11 paths, 13 operations (3 On Ramp, 4 Off Ramp, 6 Wallets), 4 Stablecoin scopes
- Playwright against the local production build and the real public OpenAPI endpoint:
  - `/stable`: HTTP 200
  - `https://api.woovi.com/api/openapi.json`: HTTP 200
  - all three groups and representative operations rendered
  - no unrelated Charge operation
  - no console errors or failed requests

## Environment

Local production build consuming the public production OpenAPI document. This static documentation portal does not provide a per-branch staging URL, and the validation did not execute authenticated API operations.

## Note

The repository pre-commit ESLint task currently reports pre-existing errors for `console`/`.mjs` usage in `docusaurus.config.js` and cannot resolve the standard Docusaurus `@theme` and `@docusaurus` aliases. The targeted change validation and full production build pass.
