### PR TITLE
fix(theme): restore light-mode page background lost in Infima upgrade

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -56,3 +56,16 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
 .explorer-fullwidth article > .markdown {
   max-width: none !important;
 }
+
+/*
+ * Infima 0.2.0-alpha.45 ships `:root { --ifm-background-color: transparent }`
+ * and only sets a concrete value for the dark theme
+ * (`html[data-theme=dark] { --ifm-background-color: #1b1b1d }`). In light mode
+ * the page background therefore resolves to `transparent`, so on a browser/OS
+ * with a dark canvas the near-black body text (`--ifm-color-content: #1c1e21`)
+ * is rendered over a dark backdrop and becomes unreadable. Restore the solid
+ * light-mode background the classic theme expects.
+ */
+html[data-theme=light] {
+  --ifm-background-color: #ffffff;
+}


### PR DESCRIPTION
## Problem

In the white/light version of the docs, the main article text has no contrast and is unreadable (reported in Slack with a screenshot). The navbar, sidebar and admonition boxes render fine — only the article body is affected.

## Root cause

Regression from the toolchain upgrade in `5b59a50 chore(deps): upgrade docusaurus, eslint and toolchain`, which pulled in **Infima `0.2.0-alpha.45`**. That release ships:

```css
:root { --ifm-background-color: transparent; }              /* light (default) */
html[data-theme=dark] { --ifm-background-color: #1b1b1d; }   /* dark only */
```

Only the **dark** theme gets a concrete background; in **light** mode `--ifm-background-color` resolves to `transparent`. On a browser/OS with a dark canvas, the near-black body text (`--ifm-color-content: #1c1e21`) is then painted straight over a dark backdrop → the broken contrast in the screenshot. Surfaces that set their own background (navbar, sidebar menu, admonitions) stay readable, which matches exactly what is reported.

Verified live on https://developers.woovi.com with Playwright — computed `--ifm-background-color` on `:root` is `transparent` in light mode.

## Fix

One-line override in `src/css/custom.css` restoring the solid light-mode background the classic theme expects:

```css
html[data-theme=light] { --ifm-background-color: #ffffff; }
```

## Evidence

Computed style on the live page, before vs. after injecting the fix (Playwright, `colorScheme: dark` context to reproduce the failing condition):

- BEFORE: `--ifm-background-color: transparent` · html bg `rgba(0,0,0,0)`
- AFTER:  `--ifm-background-color: #ffffff`  · html bg `rgb(255,255,255)`

## Notes

- Scoped to `data-theme=light` so dark mode is untouched.
- Does not revert the dependency bump; addresses the upstream default directly.