### PR TITLE
docs(stablecoin): drop the deposit lookup/list endpoints that never existed

### DIFF
--- a/docs/stablecoin/stablecoin-endpoints.md
+++ b/docs/stablecoin/stablecoin-endpoints.md
@@ -16,7 +16,6 @@ Todas as rotas ficam sob `/api/v1/stablecoin/` e exigem autenticação com o seu
 | Escopo | Rotas |
 | --- | --- |
 | `STABLECOIN_DEPOSIT_CREATE` | `quote`, `deposit`, `deposit/approve` |
-| `STABLECOIN_DEPOSIT_LIST` | `deposit/find`, `deposit` (listar) |
 | `STABLECOIN_SUBACCOUNT_CREATE` | `subaccount` (POST — solicitar KYB) |
 | `STABLECOIN_SUBACCOUNT_LIST` | `subaccount` (listar/detalhe), `wallets`, `subaccount/{id}/wallets`, `subaccount/{id}/balances` |
 | `STABLECOIN_PAYOUT_CREATE` | `payout/quote`, `payout` (criar/aprovar/consultar) |
@@ -153,44 +152,9 @@ A aprovação é rejeitada com `400` quando o depósito não pode ser aprovado, 
 { "error": "Stablecoin deposit already completed", "correlationId": "my-unique-id", "depositId": "6650abc1234def567890aaaa" }
 ```
 
-### Buscar um depósito
+### Acompanhar um depósito
 
-GET `/api/v1/stablecoin/deposit/find?correlationId={correlationId}`
-
-Busca um único depósito pelo `correlationId`.
-
-```json
-{
-  "status": "ok",
-  "deposit": {
-    "id": "6650abc1234def567890aaaa",
-    "correlationId": "my-unique-id",
-    "status": "COMPLETED",
-    "inputAmount": 10000,
-    "inputCurrency": "BRL",
-    "outputAmount": 18.45,
-    "outputCurrency": "USDT",
-    "fee": 50,
-    "createdAt": "2026-06-05T12:00:00.000Z"
-  }
-}
-```
-
-### Listar depósitos
-
-GET `/api/v1/stablecoin/deposit?limit={limit}&skip={skip}`
-
-Lista os depósitos da empresa autenticada (paginado).
-
-```json
-{
-  "status": "ok",
-  "deposits": [ { "id": "6650abc1234def567890aaaa", "status": "COMPLETED", "inputAmount": 10000, "inputCurrency": "BRL", "outputAmount": 18.45, "outputCurrency": "USDT", "fee": 50, "createdAt": "2026-06-05T12:00:00.000Z" } ],
-  "count": 42,
-  "limit": 20,
-  "skip": 0
-}
-```
+Não há rota de consulta ou listagem de depósitos. O acompanhamento é feito pelos webhooks `STABLECOIN_DEPOSIT_COMPLETED` e `STABLECOIN_DEPOSIT_FAILED` (veja [Webhooks](./stablecoin-webhooks.md)), que trazem o `correlationID` do depósito.
 
 ### Carteiras de depósito (INTERNAL float)
 

--- a/docs/stablecoin/stablecoin-flow.md
+++ b/docs/stablecoin/stablecoin-flow.md
@@ -105,10 +105,6 @@ A aprovação **debita o saldo em BRL da conta da sua empresa** (a `companyBankA
 
 Quando a stablecoin é entregue na blockchain, você recebe o webhook `STABLECOIN_DEPOSIT_COMPLETED` (com o `txHash` da transação on-chain). Em caso de falha, recebe `STABLECOIN_DEPOSIT_FAILED`.
 
-Você também pode consultar o status a qualquer momento:
-
-GET `/api/v1/stablecoin/deposit/find?correlationId=my-unique-id`
-
 ## Estados do depósito
 
 O depósito percorre os seguintes status:


### PR DESCRIPTION
## Problema

**ATIVO PAY LTDA** (company `686da126905b9a63609f40bf`) não conseguiu criar o AppID hoje. 4 tentativas em `POST /api/v1/application`, todas `400`, nenhuma criou o app:

| Hora (UTC) | Escopo recusado |
| --- | --- |
| 18:50:51 | `STABLECOIN_DEPOSIT_GET` |
| 18:51:12 | `STABLECOIN_DEPOSIT_GET` |
| 18:58:29 | `STABLECOIN_DEPOSIT_LIST` |
| 19:18:19 | `STABLECOIN_DEPOSIT_LIST` |

`{"error":"Escopos inválidos: STABLECOIN_DEPOSIT_LIST"}` — evidência no APM de prod (`traces-apm*`, `service.name: woovi-api`). Todos os outros ~50 escopos do payload são válidos; o cliente estava copiando esta doc.

## Causa

A doc descreve um escopo e duas rotas que nunca existiram:

- **O escopo não existe.** `@woovi-private/roles` publica apenas 5 escopos de stablecoin: `STABLECOIN_DEPOSIT_CREATE`, `STABLECOIN_SUBACCOUNT_LIST`, `STABLECOIN_SUBACCOUNT_CREATE`, `STABLECOIN_SWAP_CREATE`, `STABLECOIN_PAYOUT_CREATE`. `applicationValidateScopes` rejeita qualquer coisa fora dessa lista.
- **As rotas também não existem.** Em `woovi-stablecoin/src/serviceRouter.ts` as únicas rotas de depósito são `GET /quote`, `POST /deposit` e `POST /deposit/approve` — as três sob `STABLECOIN_DEPOSIT_CREATE`. Não há nenhum `GET /deposit` nem `/deposit/find`. Payout e swap têm consulta; depósito não tem.
- O OpenAPI auto-gerado (`woovi-openapi`) sempre esteve correto: só cita `STABLECOIN_DEPOSIT_CREATE`.

A linha entrou já errada em `6075946` ("docs(stablecoin): add dedicated API reference"), junto com as seções "Buscar um depósito" e "Listar depósitos" — payloads de resposta inventados incluídos.

## Mudança

- Remove a linha `STABLECOIN_DEPOSIT_LIST` da tabela de escopos.
- Remove as seções "Buscar um depósito" e "Listar depósitos".
- No lugar, "Acompanhar um depósito": diz explicitamente que não há consulta REST e aponta para os webhooks `STABLECOIN_DEPOSIT_COMPLETED` / `STABLECOIN_DEPOSIT_FAILED`, que carregam o `correlationID`.
- Remove a mesma referência a `/deposit/find` em `stablecoin-flow.md`.

Nenhuma outra página linkava as âncoras removidas (`#buscar-um-depósito`, `#listar-depósitos`).

## Fora de escopo

Se quisermos de fato expor consulta/listagem de depósito, é implementar a rota em `woovi-stablecoin` + publicar o escopo `STABLECOIN_DEPOSIT_LIST` no `woovi-roles`. Abro issue separada se fizer sentido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)