### PR TITLE
docs(kyc): document website + businessDescription on POST /api/v1/kyc/onboarding

### DIFF
--- a/docs/baas/kyc/api-onboarding-create.mdx
+++ b/docs/baas/kyc/api-onboarding-create.mdx
@@ -31,8 +31,14 @@ Para o schema, parâmetros e exemplos interativos, veja a [API Reference](/api#t
 ### Opcionais
 
 - **`correlationID`**: Identificador único para idempotência. Se não informado, o CNPJ será usado como correlationID. Se a mesma `correlationID` for enviada novamente, a API retorna o link existente (200) ao invés de criar um novo.
+- **`website`**: Site do merchant. Se informado, é persistido no AccountRegister e o merchant não precisa redigitá-lo no formulário de onboarding.
+- **`businessDescription`**: Descrição da atividade do merchant. Se informado, é persistido no AccountRegister e **destrava automaticamente a etapa `COMPANY_DATA`** do formulário — o merchant não precisa redigitá-lo. Útil quando o parceiro BaaS já coletou essa informação no próprio funil.
 - **`representatives`**: Array de sócios/representantes da empresa. Cada representante deve conter:
   - **`taxID`**: CPF do representante. Validado como CPF. Aceita formato com ou sem máscara.
+
+:::info Não-destrutivo
+`website` e `businessDescription` só são preenchidos quando estão vazios no AccountRegister. Em uma chamada idempotente (mesmo `correlationID`), um valor já informado pelo merchant **nunca é sobrescrito**.
+:::
 
 ## Exemplo
 
@@ -42,6 +48,8 @@ O body da sua requisição será semelhante a este exemplo:
 {
   "taxID": "XX.XXX.XXX/0001-XX",
   "correlationID": "my-unique-id",
+  "website": "https://loja-do-merchant.com.br",
+  "businessDescription": "Loja de roupas e acessórios femininos",
   "representatives": [
     { "taxID": "XXX.XXX.XXX-XX" },
     { "taxID": "XXX.XXX.XXX-XX" }


### PR DESCRIPTION
## Contexto

Completa a trilha de documentação do campo `businessDescription` no endpoint de KYC Onboarding, agora no site público **developers.woovi.com**:

- `woovi-kyc-backend` #982 — implementação (aceita o campo na API + OpenAPI fragments)
- `woovi-openapi` #95 — espelhou nos fragments do hub que geram o spec público (já **merged**)
- **esta PR** — o guia escrito à mão `api-onboarding-create.mdx` ainda não listava nem `website` nem `businessDescription`

## O que mudou

Em `docs/baas/kyc/api-onboarding-create.mdx`:
- Seção **Opcionais**: adicionados `website` e `businessDescription` (com a nota de que `businessDescription` destrava a etapa `COMPANY_DATA` — útil quando o parceiro BaaS já coletou a descrição no próprio funil).
- Callout **Não-destrutivo**: em replay idempotente (mesmo `correlationID`), valores já preenchidos pelo merchant nunca são sobrescritos.
- Exemplo de body atualizado com os dois campos.

## Notas

- O API Reference interativo (`/api#tag/kyc/...`) puxa de `api.woovi.com/api/openapi.json` em build-time, então herda o campo automaticamente assim que o spec público for republicado. Esta PR trata do guia narrativo, que é mantido à mão.
- Só documentação — sem mudança de código.