### PR TITLE
docs(subscription): state the payment book scope before the first call

### DIFF
--- a/docs/subscription-recurrence/subscription-payment-book-api.mdx
+++ b/docs/subscription-recurrence/subscription-payment-book-api.mdx
@@ -22,6 +22,10 @@ Para gerar, faça uma chamada GET para o _endpoint_
 [aqui](/api#tag/subscription/GET/api/v1/subscriptions/{id}/payment-book) a
 documentação referente a esse _endpoint_.
 
+Você precisa de um AppID com o escopo `SUBSCRIPTION_PAYMENT_BOOK_GET`
+([como adicionar escopos](../apis/api-scopes.md)). Ele não é um escopo de leitura:
+como a chamada cria cobranças, não o conceda a uma integração que apenas consulta.
+
 :::warning Só para assinatura recorrente
 
 O carnê existe apenas para assinaturas do tipo `RECURRENT` — as que você cria com


### PR DESCRIPTION
Follow-up to #784.

The page named `SUBSCRIPTION_PAYMENT_BOOK_GET` only in the `403` row of the error table, so the reader learned about it by getting the error. Every sibling page announces the scope before the first call:

- `docs/account-limits/api-limits-get.mdx:18` — "garanta que sua aplicação possua o scope **`ACCOUNT_LIMITS_GET`**"
- `docs/arquivos/upload-de-arquivo.md:20` — "Um AppID com o escopo `FILE_POST`"
- `docs/apis/api-account-limits-increase-request.md:32` — an "Escopo | Para quê" table near the top

This one is worth announcing twice over, so the sentence also says what the scope is: the call creates charges, so it should not be granted to a read-only integration.