### PR TITLE
fix(subscription): unbreak the build by dropping the payment book API ref anchor

### DIFF
--- a/docs/subscription-recurrence/subscription-payment-book-api.mdx
+++ b/docs/subscription-recurrence/subscription-payment-book-api.mdx
@@ -18,9 +18,8 @@ O carnê reúne em um único PDF as cobranças da sua assinatura — uma via por
 numeradas como "Parcela N de M", no formato que o seu cliente já conhece.
 
 Para gerar, faça uma chamada GET para o _endpoint_
-`/api/v1/subscriptions/{id}/payment-book`. Você pode acessar
-[aqui](/api#tag/subscription/GET/api/v1/subscriptions/{id}/payment-book) a
-documentação referente a esse _endpoint_.
+`/api/v1/subscriptions/{id}/payment-book`. Você pode acessar a
+[referência da API](/api) para os detalhes desse _endpoint_.
 
 Você precisa de um AppID com o escopo `SUBSCRIPTION_PAYMENT_BOOK_GET`
 ([como adicionar escopos](../apis/api-scopes.md)). Ele não é um escopo de leitura:


### PR DESCRIPTION
**`main` does not build right now.** Cloudflare failed at 23:39 with:

```
Error: MDX compilation failed for file "docs/subscription-recurrence/subscription-payment-book-api.mdx"
Cause: remarkApiRefLinks: … links to GET /api/v1/subscriptions/{id}/payment-book,
       which the served spec does not have
```

This blocks every deploy of the site, not just this page.

## Why

`plugins/remarkApiRefLinks.mjs:69` resolves every `/api#tag/<tag>/<METHOD>/<path>` link against **`api.woovi.com`** — production — and throws when the operation is not there. That is the plugin working as designed; it exists so a renamed tag cannot silently rot a link.

The payment book endpoint is on staging (`api.woovi.dev`, `x-commit-sha 024d54f`, 111 paths) but **not yet in production**: entria/woovi-openapi#103 merged, and production only moves on `pnpm release:patch`, which has not run. #784 merged the page before that release, so the link points at an operation the production spec does not yet serve.

## The fix

Links to the API reference index (`/api`) instead. The plugin's regex only matches the `#tag/…/METHOD/path` form, so a plain `/api` link is not resolved and cannot throw.

`pnpm build:ptbr` on this branch: **exit 0**, `[SUCCESS] Generated static files in "build"`.

## Follow-up

Once the woovi-openapi production release ships the endpoint to `api.woovi.com`, the deep link should come back — it is the better link, and the plugin will then keep it correct on its own. I will open that PR after the release; it is a one-line change.

Worth considering separately: this is the second time the ordering has bitten. The plugin validates against production, so any page documenting a not-yet-released endpoint is unmergeable until the release — which is easy to forget when three PRs land in the same minute. A CI check on the docs repo that runs `pnpm build` on the PR would have caught it before merge instead of after.