### PR TITLE
fix(theme): stop the API reference repainting every page after it

### DIFF
--- a/src/components/ScalarApiReference/index.tsx
+++ b/src/components/ScalarApiReference/index.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+
+// Loads Scalar on the client and undoes the one thing it leaves behind.
+//
+// @scalar/use-hooks writes `light-mode`/`dark-mode` on document.body and its
+// own teardown drops only the matchMedia listener, so under SPA navigation the
+// class outlives the page. Scalar's stylesheet ships in the single Docusaurus
+// bundle and carries `body { background-color: var(--scalar-background-1) }`,
+// a variable defined only on those two classes — so an orphaned class repaints
+// every later route (white docs in dark mode), and removing it makes the whole
+// sheet inert again. Upstream fixes the same defect in its CDN build with
+// retainStandaloneStyles/releaseStandaloneStyles, which this bundle cannot reach.
+//
+// Every page that renders Scalar goes through here: the six copies of this
+// loader were identical apart from the spec url, and /api being the one copy
+// that drifted is why the leak shipped.
+export default function ScalarApiReference({
+  configuration,
+}: {
+  configuration: Record<string, unknown>;
+}) {
+  const [ApiReference, setApiReference] =
+    useState<React.ComponentType<{ configuration: unknown }> | null>(null);
+
+  useEffect(() => {
+    const state = { mounted: true };
+
+    (async () => {
+      const [mod] = await Promise.all([
+        import('@scalar/api-reference-react'),
+        import('@scalar/api-reference-react/style.css'),
+      ]);
+
+      if (!state.mounted) return;
+
+      setApiReference(() => mod.ApiReferenceReact);
+    })();
+
+    return () => {
+      state.mounted = false;
+      document.body.classList.remove('light-mode', 'dark-mode');
+    };
+  }, []);
+
+  if (!ApiReference) return <div>Loading...</div>;
+
+  return (
+    <div style={{ height: 'calc(100vh - 60px)' }}>
+      <ApiReference configuration={configuration} />
+    </div>
+  );
+}

--- a/src/pages/api-elements.tsx
+++ b/src/pages/api-elements.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
+// eslint-disable-next-line import/no-unresolved
 import BrowserOnly from '@docusaurus/BrowserOnly';
+// eslint-disable-next-line import/no-unresolved
 import Layout from '@theme/Layout';
 
 function ApiElementsInner() {
   const [Component, setComponent] =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     React.useState<React.ComponentType<any> | null>(null);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -31,6 +34,8 @@ function ApiElementsInner() {
 
     return () => {
       mounted = false;
+      // Stoplight's sheet restyles bare html/body, so it must not outlive the page.
+      link.remove();
     };
   }, []);
 
@@ -53,9 +58,9 @@ function ApiElementsInner() {
   return (
     <div style={{ height: 'calc(100vh - 60px)' }}>
       <Component
-        apiDescriptionUrl="https://api.woovi.com/api/openapi.json"
-        router="hash"
-        layout="sidebar"
+        apiDescriptionUrl='https://api.woovi.com/api/openapi.json'
+        router='hash'
+        layout='sidebar'
       />
     </div>
   );
@@ -64,8 +69,8 @@ function ApiElementsInner() {
 export default function ApiElements() {
   return (
     <Layout
-      title="Woovi API - Stoplight Elements"
-      description="Woovi API Documentation with Stoplight Elements"
+      title='Woovi API - Stoplight Elements'
+      description='Woovi API Documentation with Stoplight Elements'
     >
       <BrowserOnly fallback={<div style={{ padding: '20px' }}>Loading...</div>}>
         {() => <ApiElementsInner />}

--- a/src/pages/api-scalar.tsx
+++ b/src/pages/api-scalar.tsx
@@ -1,47 +1,26 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+// eslint-disable-next-line import/no-unresolved
 import BrowserOnly from '@docusaurus/BrowserOnly';
+// eslint-disable-next-line import/no-unresolved
 import Layout from '@theme/Layout';
 
-function ApiScalarInner() {
-  const [ApiReference, setApiReference] = useState(null);
+import ScalarApiReference from '../components/ScalarApiReference';
 
-  useEffect(() => {
-    let mounted = true;
-
-    (async () => {
-      const mod = await import('@scalar/api-reference-react');
-      await import('@scalar/api-reference-react/style.css');
-
-      if (mounted) setApiReference(() => mod.ApiReferenceReact);
-    })();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  if (!ApiReference) return <div>Loading...</div>;
-
-  return (
-    <div style={{ height: 'calc(100vh - 60px)' }}>
-      <ApiReference
-        configuration={{
-          url: 'https://api.woovi.com/api/openapi.json',
-          theme: 'default',
-        }}
-      />
-    </div>
-  );
-}
-
-export default function ApiScalar() {
+export default function WooviApiScalarPage() {
   return (
     <Layout
-      title="Woovi API - Scalar"
-      description="Woovi API Documentation with Scalar"
+      title='Woovi API - Scalar'
+      description='Woovi API Documentation with Scalar'
     >
       <BrowserOnly fallback={<div>Loading...</div>}>
-        {() => <ApiScalarInner />}
+        {() => (
+          <ScalarApiReference
+            configuration={{
+              url: 'https://api.woovi.com/api/openapi.json',
+              theme: 'default',
+            }}
+          />
+        )}
       </BrowserOnly>
     </Layout>
   );

--- a/src/pages/api.tsx
+++ b/src/pages/api.tsx
@@ -1,47 +1,26 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+// eslint-disable-next-line import/no-unresolved
 import BrowserOnly from '@docusaurus/BrowserOnly';
+// eslint-disable-next-line import/no-unresolved
 import Layout from '@theme/Layout';
 
-function ApiScalarInner() {
-  const [ApiReference, setApiReference] = useState(null);
+import ScalarApiReference from '../components/ScalarApiReference';
 
-  useEffect(() => {
-    let mounted = true;
-
-    (async () => {
-      const mod = await import('@scalar/api-reference-react');
-      await import('@scalar/api-reference-react/style.css');
-
-      if (mounted) setApiReference(() => mod.ApiReferenceReact);
-    })();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  if (!ApiReference) return <div>Loading...</div>;
-
-  return (
-    <div style={{ height: 'calc(100vh - 60px)' }}>
-      <ApiReference
-        configuration={{
-          url: 'https://api.woovi.com/api/openapi.json',
-          theme: 'default',
-        }}
-      />
-    </div>
-  );
-}
-
-export default function ApiScalar() {
+export default function WooviApiPage() {
   return (
     <Layout
-      title="Woovi API"
-      description="Woovi API Documentation"
+      title='Woovi API'
+      description='Woovi API Documentation'
     >
       <BrowserOnly fallback={<div>Loading...</div>}>
-        {() => <ApiScalarInner />}
+        {() => (
+          <ScalarApiReference
+            configuration={{
+              url: 'https://api.woovi.com/api/openapi.json',
+              theme: 'default',
+            }}
+          />
+        )}
       </BrowserOnly>
     </Layout>
   );

--- a/src/pages/dict-scalar.tsx
+++ b/src/pages/dict-scalar.tsx
@@ -1,47 +1,26 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+// eslint-disable-next-line import/no-unresolved
 import BrowserOnly from '@docusaurus/BrowserOnly';
+// eslint-disable-next-line import/no-unresolved
 import Layout from '@theme/Layout';
 
-function ApiScalarInner() {
-  const [ApiReference, setApiReference] = useState(null);
+import ScalarApiReference from '../components/ScalarApiReference';
 
-  useEffect(() => {
-    let mounted = true;
-
-    (async () => {
-      const mod = await import('@scalar/api-reference-react');
-      await import('@scalar/api-reference-react/style.css');
-
-      if (mounted) setApiReference(() => mod.ApiReferenceReact);
-    })();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  if (!ApiReference) return <div>Loading...</div>;
-
-  return (
-    <div style={{ height: 'calc(100vh - 60px)' }}>
-      <ApiReference
-        configuration={{
-          url: '/swaggers/bacen-dict.json',
-          theme: 'default',
-        }}
-      />
-    </div>
-  );
-}
-
-export default function ApiScalar() {
+export default function BacenDictApiPage() {
   return (
     <Layout
-      title="Bacen DICT API"
-      description="Bacen DICT API Documentation"
+      title='Bacen DICT API'
+      description='Bacen DICT API Documentation'
     >
       <BrowserOnly fallback={<div>Loading...</div>}>
-        {() => <ApiScalarInner />}
+        {() => (
+          <ScalarApiReference
+            configuration={{
+              url: '/swaggers/bacen-dict.json',
+              theme: 'default',
+            }}
+          />
+        )}
       </BrowserOnly>
     </Layout>
   );

--- a/src/pages/indirect-scalar.tsx
+++ b/src/pages/indirect-scalar.tsx
@@ -1,47 +1,26 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+// eslint-disable-next-line import/no-unresolved
 import BrowserOnly from '@docusaurus/BrowserOnly';
+// eslint-disable-next-line import/no-unresolved
 import Layout from '@theme/Layout';
 
-function ApiScalarInner() {
-  const [ApiReference, setApiReference] = useState(null);
+import ScalarApiReference from '../components/ScalarApiReference';
 
-  useEffect(() => {
-    let mounted = true;
-
-    (async () => {
-      const mod = await import('@scalar/api-reference-react');
-      await import('@scalar/api-reference-react/style.css');
-
-      if (mounted) setApiReference(() => mod.ApiReferenceReact);
-    })();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  if (!ApiReference) return <div>Loading...</div>;
-
-  return (
-    <div style={{ height: 'calc(100vh - 60px)' }}>
-      <ApiReference
-        configuration={{
-          url: '/swaggers/pixIndirect.json',
-          theme: 'default',
-        }}
-      />
-    </div>
-  );
-}
-
-export default function ApiScalar() {
+export default function WooviPixIndirectApiPage() {
   return (
     <Layout
-      title="Woovi Pix IndirectAPI"
-      description="Woovi Pix Indirect API Documentation"
+      title='Woovi Pix Indirect API'
+      description='Woovi Pix Indirect API Documentation'
     >
       <BrowserOnly fallback={<div>Loading...</div>}>
-        {() => <ApiScalarInner />}
+        {() => (
+          <ScalarApiReference
+            configuration={{
+              url: '/swaggers/pixIndirect.json',
+              theme: 'default',
+            }}
+          />
+        )}
       </BrowserOnly>
     </Layout>
   );

--- a/src/pages/pix-scalar.tsx
+++ b/src/pages/pix-scalar.tsx
@@ -1,47 +1,26 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+// eslint-disable-next-line import/no-unresolved
 import BrowserOnly from '@docusaurus/BrowserOnly';
+// eslint-disable-next-line import/no-unresolved
 import Layout from '@theme/Layout';
 
-function ApiScalarInner() {
-  const [ApiReference, setApiReference] = useState(null);
+import ScalarApiReference from '../components/ScalarApiReference';
 
-  useEffect(() => {
-    let mounted = true;
-
-    (async () => {
-      const mod = await import('@scalar/api-reference-react');
-      await import('@scalar/api-reference-react/style.css');
-
-      if (mounted) setApiReference(() => mod.ApiReferenceReact);
-    })();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  if (!ApiReference) return <div>Loading...</div>;
-
-  return (
-    <div style={{ height: 'calc(100vh - 60px)' }}>
-      <ApiReference
-        configuration={{
-          url: '/swaggers/bacen-pix.yaml',
-          theme: 'default',
-        }}
-      />
-    </div>
-  );
-}
-
-export default function ApiScalar() {
+export default function BacenPixApiPage() {
   return (
     <Layout
-      title="Bacen Pix API"
-      description="Bacen Pix API Documentation"
+      title='Bacen Pix API'
+      description='Bacen Pix API Documentation'
     >
       <BrowserOnly fallback={<div>Loading...</div>}>
-        {() => <ApiScalarInner />}
+        {() => (
+          <ScalarApiReference
+            configuration={{
+              url: '/swaggers/bacen-pix.yaml',
+              theme: 'default',
+            }}
+          />
+        )}
       </BrowserOnly>
     </Layout>
   );

--- a/src/pages/stable.tsx
+++ b/src/pages/stable.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 
+// eslint-disable-next-line import/no-unresolved
 import BrowserOnly from '@docusaurus/BrowserOnly';
+// eslint-disable-next-line import/no-unresolved
 import Layout from '@theme/Layout';
 
 import { buildStableOpenApi } from '../openapi/stableOpenApi';
@@ -68,6 +70,8 @@ function StableApiReference() {
     return () => {
       mounted = false;
       abortController.abort();
+      // @scalar/use-hooks writes this class on document.body and never removes it.
+      document.body.classList.remove('light-mode', 'dark-mode');
     };
   }, []);
 


### PR DESCRIPTION
Reported: open `/api`, navigate back to `/docs/intro/getting-started`, and the docs page keeps the API reference's background. In dark mode it is white page + light-grey text — unreadable.

Reproduced against the built site with headless Chromium, theme = dark:

| | `body.className` | `body` background |
| --- | --- | --- |
| direct load of the docs page | `""` | `rgba(0, 0, 0, 0)` |
| on `/api` | `light-mode` | `rgb(255, 255, 255)` |
| **back on the docs page** | `light-mode` | `rgb(255, 255, 255)` ← bug |

## Cause

`@scalar/use-hooks/dist/useColorMode/useColorMode.js:60-75` writes `light-mode` / `dark-mode` on `document.body`; its `onUnmounted` (`:99-101`) removes only the matchMedia listener. The class outlives the page.

Docusaurus emits **one** CSS bundle (`styles.8e41e447.css`, `find build -name '*.css' | wc -l` → 1), so Scalar's

```css
body { margin: 0; background-color: var(--scalar-background-1) }
```

is already on every route, visited `/api` or not. `--scalar-background-1` is defined **only** on those two classes, so with a clean `body` the `var()` is invalid at computed-value time and the declaration falls back to `transparent`. The orphaned class is the entire bug, and removing it makes the whole sheet inert — this fix leaves the bundle hash unchanged, which is the proof that the stylesheet was never the lever.

`color-scheme` flipping to `light` comes along for the ride, which is the native scrollbars and form controls going wrong too.

Upstream treats this as a teardown bug and fixes it in the CDN build with reference-counted `retainStandaloneStyles` / `releaseStandaloneStyles` (`@scalar/api-reference/dist/standalone/lib/html-api.js:13-24`, whose comment describes this scenario). That build is not reachable from the bundler, so the same class of fix is applied here.

## Why one shared component and not six one-liners

The six Scalar loaders were **byte-identical apart from the spec url** — I diffed each. `/api` being the one copy that drifted (double quotes, no eslint-disables, different export name) is why the leak shipped: four of the pages could have been fixed together and `/api` would still have been broken. The teardown now lives in `src/components/ScalarApiReference`, which every Scalar page goes through, and the duplication that hid the bug is gone (−180 lines).

`/stable` keeps its own loader — it builds the spec rather than fetching a url — and gets the same one-line cleanup.

## Also fixed: the same defect on `/api-elements`

That page appends a `<link>` to `https://unpkg.com/@stoplight/elements@8.3.0/styles.min.css` in an effect and never removes it, so Stoplight's CSS leaks the same way. It now removes the element on unmount. (Separately worth a look: that page pulls CSS from a third-party CDN at runtime.)

## Verified

- `pnpm build:ptbr` → exit 0
- back on the docs page after `/api`: `body.className` `""`, background `rgba(0, 0, 0, 0)` — byte-identical to a direct load, in **both** themes
- all 7 renderer pages still render, 0 console errors
- CSS bundle hash unchanged

## Note on lint

`api-elements.tsx` and `stable.tsx` had never been linted — `lint-staged` only covers staged files and nothing had staged them. Touching them surfaced pre-existing errors (`import/no-unresolved` on `@docusaurus/*` / `@theme/*`, one `no-explicit-any`, and JSX double quotes). Suppressed the first two the way the other seven pages in `src/pages/` already do, and `eslint --fix` normalised the quotes. None of that is behaviour change, but it is why those two files show more diff than two lines.